### PR TITLE
Spatial IR Syntax Implementation

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.12
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
-        python-version: "3.12"
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/spatialstencil/syntax/common/basenode.py
+++ b/spatialstencil/syntax/common/basenode.py
@@ -82,8 +82,6 @@ class BaseNode:
         for field_name, field in cls.__dataclass_fields__.items():
             # Resolve the field's type using get_type_hints (handling forward references)
             field_type = type_hints[field_name]
-            print(field_type)
-
             origin = typing.get_origin(field_type)
             if origin is types.UnionType or origin is typing.Union:
                 _check_union(field_type, field_name)

--- a/spatialstencil/syntax/common/basenode.py
+++ b/spatialstencil/syntax/common/basenode.py
@@ -33,7 +33,7 @@ class BaseNode:
     """
 
     @classmethod
-    def validate_schema(cls, visited: set[type['BaseNode']] = None) -> bool:
+    def validate_schema(cls, visited: set[type['BaseNode']] = None):
         """
         Validates that the node type and all its child node types abide by
         the rules defined on ``BaseNode``.
@@ -94,7 +94,6 @@ class BaseNode:
             else:
                 if not isinstance(field_type, type) or not issubclass(field_type, (int, float, str, type(None), Enum)):
                     raise TypeError(f'Unsupported terminator type {field_type} for field {field_name} of {cls}')
-        return True
 
     def validate(self) -> None:
         """

--- a/spatialstencil/syntax/common/basenode.py
+++ b/spatialstencil/syntax/common/basenode.py
@@ -3,6 +3,7 @@ Provides a base class for AST/IR trees. Includes children queries and schema val
 """
 import types
 import typing
+import warnings
 from dataclasses import dataclass
 from collections import deque
 import pprint
@@ -44,19 +45,26 @@ class BaseNode:
             return True
         visited.add(cls)
 
-        def _check_sequence(sequence, field_name):
+        def _check_sequence(sequence, f_name):
+
             for item in typing.get_args(sequence):
+                if isinstance(item, str):
+                    warnings.warn(f"Could not validate schema for field {f_name} of {cls} due to forward reference")
+                    continue
                 if typing.get_origin(item) is types.UnionType or typing.get_origin(item) is typing.Union:
                     _check_union(item, field_name)
                 elif issubclass(item, BaseNode):
                     item.validate_schema(visited)
                 elif not isinstance(item, type) or not issubclass(item, (int, float, str, type(None), Enum)):
-                    raise TypeError(f'Unsupported sequence content {item} for field {field_name} of {cls}')
+                    raise TypeError(f'Unsupported sequence content {item} for field {f_name} of {cls}')
 
         def _check_union(union, f_name):
             for subtype in typing.get_args(union):
                 # Handle Literal or None types
                 if typing.get_origin(subtype) is typing.Literal or subtype is type(None):
+                    continue
+                if isinstance(subtype, str):
+                    warnings.warn(f"Could not validate schema for field {f_name} of {cls} due to forward reference")
                     continue
                 if isinstance(typing.get_origin(subtype), (list, type)):
                     _check_sequence(subtype, f_name)
@@ -74,6 +82,7 @@ class BaseNode:
         for field_name, field in cls.__dataclass_fields__.items():
             # Resolve the field's type using get_type_hints (handling forward references)
             field_type = type_hints[field_name]
+            print(field_type)
 
             origin = typing.get_origin(field_type)
             if origin is types.UnionType or origin is typing.Union:

--- a/spatialstencil/syntax/common/basenode.py
+++ b/spatialstencil/syntax/common/basenode.py
@@ -1,9 +1,12 @@
 """
 Provides a base class for AST/IR trees. Includes children queries and schema validation.
 """
+import types
+import typing
 from dataclasses import dataclass
 from collections import deque
 import pprint
+from enum import Enum
 
 
 @dataclass
@@ -29,7 +32,7 @@ class BaseNode:
     """
 
     @classmethod
-    def validate_schema(cls, visited: set[type['BaseNode']] = None) -> None:
+    def validate_schema(cls, visited: set[type['BaseNode']] = None) -> bool:
         """
         Validates that the node type and all its child node types abide by
         the rules defined on ``BaseNode``.
@@ -38,23 +41,53 @@ class BaseNode:
         """
         visited = visited or set()
         if cls in visited:  # Skip type cycles
-            return
+            return True
         visited.add(cls)
 
+        def _check_sequence(sequence, field_name):
+            for item in typing.get_args(sequence):
+                if typing.get_origin(item) is types.UnionType or typing.get_origin(item) is typing.Union:
+                    _check_union(item, field_name)
+                elif issubclass(item, BaseNode):
+                    item.validate_schema(visited)
+                elif not isinstance(item, type) or not issubclass(item, (int, float, str, type(None), Enum)):
+                    raise TypeError(f'Unsupported sequence content {item} for field {field_name} of {cls}')
+
+        def _check_union(union, f_name):
+            for subtype in typing.get_args(union):
+                # Handle Literal or None types
+                if typing.get_origin(subtype) is typing.Literal or subtype is type(None):
+                    continue
+                if isinstance(typing.get_origin(subtype), (list, type)):
+                    _check_sequence(subtype, f_name)
+                # Handle BaseNode subclasses
+                elif isinstance(subtype, type) and issubclass(subtype, BaseNode):
+                    subtype.validate_schema(visited)
+                # Raise error for unsupported types
+                elif not isinstance(subtype, type) or not issubclass(subtype,
+                                                                   (BaseNode, int, float, str, type(None), Enum)):
+                    raise TypeError(f'Unsupported union type {subtype} for field {f_name} of {cls}')
+
+        # Use get_type_hints to resolve forward references
+        type_hints = typing.get_type_hints(cls)
+
         for field_name, field in cls.__dataclass_fields__.items():
-            if issubclass(field.type, BaseNode):
-                # Traverse
-                field.type.validate_schema(visited)
-            elif hasattr(field.type, '__origin__') and issubclass(field.type.__origin__, (tuple, list)):  # Sequence
-                # Check that contents must be either a terminator or a node
-                for subtype in field.type.__args__:
-                    if issubclass(subtype, BaseNode):
-                        subtype.validate_schema(visited)
-                    if not issubclass(subtype, (BaseNode, int, float, str, type(None))):
-                        raise TypeError(f'Unsupported sequence content "{subtype}" for field {field_name} of {cls}')
+            # Resolve the field's type using get_type_hints (handling forward references)
+            field_type = type_hints[field_name]
+
+            origin = typing.get_origin(field_type)
+            if origin is types.UnionType or origin is typing.Union:
+                _check_union(field_type, field_name)
+            elif isinstance(field_type, type) and issubclass(field_type, BaseNode):
+                # Traverse if it’s a BaseNode subclass
+                field_type.validate_schema(visited)
+            elif origin and issubclass(origin, (tuple, list)):  # Sequence
+                # Check contents of sequences
+                _check_sequence(field_type, field_name)
             else:
-                if not issubclass(field.type, (int, float, str, type(None))):
-                    raise TypeError(f'Unsupported terminator type "{field.type}" for field {field_name} of {cls}')
+                if not isinstance(field_type, type) or not issubclass(field_type, (int, float, str, type(None), Enum)):
+                    raise TypeError(f'Unsupported terminator type {field_type} for field {field_name} of {cls}')
+        return True
 
     def validate(self) -> None:
         """

--- a/spatialstencil/syntax/common/basenode.py
+++ b/spatialstencil/syntax/common/basenode.py
@@ -63,6 +63,9 @@ class BaseNode:
         """
         pass  # Nothing to validate
 
+    def __post_init__(self):
+        self.validate()
+
     def pretty(self) -> str:
         """
         Pretty-prints the contents of this node.

--- a/spatialstencil/syntax/common/types.py
+++ b/spatialstencil/syntax/common/types.py
@@ -1,0 +1,40 @@
+import enum
+
+
+class IRType:
+    """
+    Interface that indicates this node represents a type.
+    """
+    pass
+
+
+class ScalarType(enum.Enum):
+    UNKNOWN = enum.auto()  # Not yet type-inferred
+    i8 = enum.auto()
+    i16 = enum.auto()
+    i32 = enum.auto()
+    u8 = enum.auto()
+    u16 = enum.auto()
+    u32 = enum.auto()
+    f16 = enum.auto()
+    f32 = enum.auto()
+    f64 = enum.auto()
+    bool = enum.auto()
+
+    def as_ir(self, indent: int = 0) -> str:
+        return self.name
+
+
+BIT_WIDTH = {
+    ScalarType.UNKNOWN: 0,
+    ScalarType.i8: 8,
+    ScalarType.i16: 16,
+    ScalarType.i32: 32,
+    ScalarType.u8: 8,
+    ScalarType.u16: 16,
+    ScalarType.u32: 32,
+    ScalarType.f16: 16,
+    ScalarType.f32: 32,
+    ScalarType.f64: 64,
+    ScalarType.bool: 1,
+}

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Union, Tuple, Optional
+from typing import Union, Tuple, Optional
 from spatialstencil.syntax.common.basenode import BaseNode
 from spatialstencil.syntax.common.types import ScalarType, IRType
 
@@ -72,7 +72,7 @@ class ArrayType(SpatialNode, IRType):
     An array type of a scalar or stream, with one or more dimensions.
     """
     base_type: Union[ScalarType, StreamType]
-    dimensions: List[Union[int, Parameter]]
+    dimensions: list[Union[int, Parameter]]
 
     def as_ir(self, indent: int = 0) -> str:
         dims = ", ".join(str(dim.as_ir() if isinstance(dim, SpatialNode) else dim) for dim in self.dimensions)
@@ -122,7 +122,7 @@ class ArraySlice(SpatialNode):
     For stride access: array[start:end:stride]
     """
     array: Identifier
-    indices: List[Union[int, Identifier, 'RangeExpression']]  # Handles single-index or ranges
+    indices: list[Union[int, Identifier, 'RangeExpression']]  # Handles single-index or ranges
 
     def as_ir(self, indent: int = 0) -> str:
         index_strs = []
@@ -213,9 +213,9 @@ class Kernel(SpatialNode):
     A kernel definition.
     """
     name: str
-    parameters: List[Parameter]
-    arguments: List[KernelArgument]
-    body: List[SpatialNode]
+    parameters: list[Parameter]
+    arguments: list[KernelArgument]
+    body: list[SpatialNode]
 
     def as_ir(self, indent: int = 0) -> str:
         param_str = ", ".join(p.as_ir() for p in self.parameters)
@@ -270,9 +270,9 @@ class PlaceBlock(SpatialNode):
     The 'place' block for allocating variables or arrays on a subgrid of PEs.
     """
     variable_type: ScalarType
-    variables: List[Identifier]
+    variables: list[Identifier]
     subgrid: SubgridExpression
-    statements: List[FieldDeclaration]
+    statements: list[FieldDeclaration]
 
     def as_ir(self, indent: int = 0) -> str:
         vars_str = ", ".join(v.as_ir() for v in self.variables)
@@ -286,7 +286,7 @@ class RoutingDeclaration(SpatialNode):
     """
     A routing declaration for a stream, optionally specifying hops and channel.
     """
-    hops: Union[List[Tuple[int, int]], str] = "auto"  # List of hops or 'auto'
+    hops: Union[list[Tuple[int, int]], str] = "auto"  # list of hops or 'auto'
     channel: Union[int, str] = "auto"  # Channel ID or 'auto'
 
     def validate(self) -> None:
@@ -326,9 +326,9 @@ class DataflowBlock(SpatialNode):
     """
     The 'dataflow' block for describing communication streams between PEs.
     """
-    variables: List[Identifier]
+    variables: list[Identifier]
     subgrid: SubgridExpression
-    statements: List[RelativeStreamDeclaration]
+    statements: list[RelativeStreamDeclaration]
 
     def as_ir(self, indent: int = 0) -> str:
         vars_str = ", ".join(v.as_ir() for v in self.variables)
@@ -375,7 +375,7 @@ class SendStatement(Statement):
 
 # Receive Statement
 @dataclass
-class ReceiveStatement(SpatialNode):
+class Receive(SpatialNode):
     """
     Receive data from a stream.
     """
@@ -391,9 +391,9 @@ class ForeachStatement(Statement):
     """
     Foreach loop for asynchronously iterating over a received stream.
     """
-    variables: List[Identifier]
-    receive_stream: ReceiveStatement
-    body: List[Statement]
+    variables: list[Identifier]
+    receive_stream: Receive
+    body: list[Statement]
     completion_name: Optional[Completion] = None
     parameter_range: Optional[RangeExpression] = None
 
@@ -411,9 +411,9 @@ class MapStatement(Statement):
     """
     Map statement for applying an affine computation asynchronously to array elements.
     """
-    variables: List[Identifier]
+    variables: list[Identifier]
     range_expression: RangeExpression
-    body: List[Statement]
+    body: list[Statement]
     completion_name: Optional[Completion] = None
 
     def as_ir(self, indent: int = 0) -> str:
@@ -428,9 +428,9 @@ class ForStatement(Statement):
     """
     Sequential for loop for iterating over a range expression.
     """
-    variables: List[Identifier]
+    variables: list[Identifier]
     range_expression: RangeExpression
-    body: List[Statement]
+    body: list[Statement]
 
     def as_ir(self, indent: int = 0) -> str:
         vars_str = ", ".join(var.as_ir() for var in self.variables)
@@ -444,7 +444,7 @@ class AsyncBlock(Statement):
     """
     Asynchronous block for executing a computation asynchronously.
     """
-    body: List[Statement]
+    body: list[Statement]
     completion_name: Optional[Completion] = None
 
     def as_ir(self, indent: int = 0) -> str:
@@ -470,9 +470,9 @@ class ComputeBlock(SpatialNode):
     """
     The 'compute' block for defining computation on a subgrid of PEs.
     """
-    variables: List[Identifier]
+    variables: list[Identifier]
     subgrid: SubgridExpression
-    statements: List[Statement]
+    statements: list[Statement]
 
     def as_ir(self, indent: int = 0) -> str:
         vars_str = ", ".join(var.as_ir() for var in self.variables)
@@ -485,9 +485,9 @@ class Phase(SpatialNode):
     """
     Encapsulates a phase of data placement, communication, and computation.
     """
-    placement: List[PlaceBlock]
-    dataflow: List[DataflowBlock]
-    compute: List[ComputeBlock]
+    placement: list[PlaceBlock]
+    dataflow: list[DataflowBlock]
+    compute: list[ComputeBlock]
 
     def as_ir(self, indent: int = 0) -> str:
         phase_str = "phase {\n"

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -430,6 +430,25 @@ class AwaitStatement(Statement):
         return f'{indent_str}await {self.completion.as_ir()}'
 
 
+# Assignment Statement
+
+@dataclass
+class AssignmentStatement(Statement):
+    """
+    Assigns the result of an expression to a field or variable
+    """
+    source: Expression
+    destination: ArraySlice | Identifier
+
+    def validate(self) -> None:
+        assert isinstance(self.source, Expression)
+        assert isinstance(self.destination, (ArraySlice, Identifier))
+
+    def as_ir(self, indent: int = 0) -> str:
+        indent_str = '  ' * indent
+        return f'{indent_str}{self.destination.as_ir()} = {self.source.as_ir()}'
+
+
 # Compute Block
 @dataclass
 class ComputeBlock(SpatialNode):

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Union, Tuple, Optional
 from spatialstencil.syntax.common.basenode import BaseNode
 from spatialstencil.syntax.common.types import ScalarType
@@ -118,6 +118,7 @@ class ArraySlice(SpatialNode):
     Represents a subscript or slice of an array.
     For single index access: array[i]
     For range access: array[start:end]
+    For stride access: array[start:end:stride]
     """
     array: Identifier
     indices: List[Union[int, Identifier, 'RangeExpression']]  # Handles single-index or ranges
@@ -213,7 +214,7 @@ class Kernel(SpatialNode):
     name: str
     parameters: List[Parameter]
     arguments: List[KernelArgument]
-    body: List['Expression']
+    body: List[SpatialNode]
 
     def as_ir(self, indent: int = 0) -> str:
         param_str = ", ".join(p.as_ir() for p in self.parameters)
@@ -226,7 +227,7 @@ class Kernel(SpatialNode):
 @dataclass
 class Expression(SpatialNode):
     """
-    A general expression that can take the form of an identifier, literal, subscript, unary/binary operator, etc.
+    A general expression that can take the form of an identifier, literal, array slice, unary/binary operator, etc.
     """
     value: Union[Identifier, ConstantLiteral, Parameter, ArraySlice, UnaryOperator, BinaryOperator, BoolExpression]
 
@@ -258,7 +259,7 @@ class FieldDeclaration(SpatialNode):
     field_name: Identifier
 
     def as_ir(self, indent: int = 0) -> str:
-        return f'{self.field_type.as_ir()} {self.field_name.as_ir()};'
+        return f'{self.field_type.as_ir()} {self.field_name.as_ir()}'
 
 
 # Place Block
@@ -295,7 +296,7 @@ class RoutingDeclaration(SpatialNode):
     def as_ir(self, indent: int = 0) -> str:
         hops_str = "auto" if self.hops == "auto" else f"[{', '.join(f'({dx}, {dy})' for dx, dy in self.hops)}]"
         channel_str = "auto" if self.channel == "auto" else str(self.channel)
-        return f"hops = {hops_str};\n{' ' * indent}channel = {channel_str};"
+        return f"hops = {hops_str}, \n{' ' * indent}channel = {channel_str}"
 
 
 # Relative Stream Declaration with Optional Routing
@@ -315,7 +316,7 @@ class RelativeStreamDeclaration(SpatialNode):
         routing_str = ""
         if self.routing:
             routing_str = f" {{\n{self.routing.as_ir(indent + 2)}\n{' ' * indent}}}"
-        return f'stream<{self.stream_type.element_type.as_ir()}> {self.stream_name.as_ir()} = relative_stream({self.dx.as_ir()}, {self.dy.as_ir()}){routing_str};'
+        return (f'stream<{self.stream_type.element_type.as_ir()}> {self.stream_name.as_ir()} = relative_stream({self.dx.as_ir()}, {self.dy.as_ir()}){routing_str}')
 
 
 # Dataflow Block
@@ -367,8 +368,8 @@ class SendStatement(Statement):
 
     def as_ir(self, indent: int = 0) -> str:
         if self.completion_name:
-            return f'{self.completion_name.as_ir()} = send({self.local_array.as_ir()}, {self.stream_name.as_ir()});'
-        return f'send({self.local_array.as_ir()}, {self.stream_name.as_ir()});'
+            return f'{self.completion_name.as_ir()} = send({self.local_array.as_ir()}, {self.stream_name.as_ir()})'
+        return f'send({self.local_array.as_ir()}, {self.stream_name.as_ir()})'
 
 
 # Receive Statement
@@ -456,10 +457,10 @@ class AwaitStatement(Statement):
     """
     Await statement to wait for a completion.
     """
-    completion_name: Completion
+    completion: Completion
 
     def as_ir(self, indent: int = 0) -> str:
-        return f'await {self.completion_name.as_ir()};'
+        return f'await {self.completion.as_ir()}'
 
 
 # Compute Block
@@ -476,3 +477,21 @@ class ComputeBlock(SpatialNode):
         vars_str = ", ".join(var.as_ir() for var in self.variables)
         stmt_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.statements)
         return f'compute {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n}}'
+
+
+@dataclass
+class Phase(SpatialNode):
+    """
+    Encapsulates a phase of data placement, communication, and computation.
+    """
+    placement: List[PlaceBlock]
+    dataflow: List[DataflowBlock]
+    compute: List[ComputeBlock]
+
+    def as_ir(self, indent: int = 0) -> str:
+        phase_str = "phase {\n"
+        dataflow_str = "\n".join(df.as_ir(indent + 2) for df in self.dataflows)
+        compute_str = "\n".join(cmp.as_ir(indent + 2) for cmp in self.computes)
+        place_str = "\n".join(pl.as_ir(indent + 2) for pl in self.places)
+        return f'{phase_str}{dataflow_str}\n{compute_str}\n{place_str}\n{" " * indent}}}'
+

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Union, Tuple, Optional
+from typing import Union, Tuple, Optional, Literal
 from spatialstencil.syntax.common.basenode import BaseNode
 from spatialstencil.syntax.common.types import ScalarType, IRType
 
@@ -21,7 +21,7 @@ class ConstantLiteral(SpatialNode):
     A constant literal (e.g., 0, 1, -12).
     """
     value: Union[int, float]
-    type: ScalarType
+    dtype: ScalarType
 
     def as_ir(self, indent: int = 0) -> str:
         return str(self.value)
@@ -59,10 +59,10 @@ class StreamType(SpatialNode, IRType):
     """
     A stream type that sends elements of type T.
     """
-    element_type: ScalarType
+    dtype: ScalarType
 
     def as_ir(self, indent: int = 0) -> str:
-        return f'stream<{self.element_type.as_ir()}>'
+        return f'stream<{self.dtype.as_ir()}>'
 
 
 # Arrays
@@ -73,6 +73,11 @@ class ArrayType(SpatialNode, IRType):
     """
     base_type: Union[ScalarType, StreamType]
     dimensions: list[Union[int, Parameter]]
+
+    def validate(self) -> None:
+        assert isinstance(self.dimensions, list)
+        assert all(isinstance(dim, (int, Parameter)) for dim in self.dimensions)
+        assert len(self.dimensions) > 0
 
     def as_ir(self, indent: int = 0) -> str:
         dims = ", ".join(str(dim.as_ir() if isinstance(dim, SpatialNode) else dim) for dim in self.dimensions)
@@ -141,7 +146,11 @@ class Expression(SpatialNode):
     A general expression that can take the form of an identifier, literal, array slice, unary/binary operator, etc.
     """
     value: Union[Identifier, ConstantLiteral, Parameter, ArraySlice, UnaryOperator, BinaryOperator]
-    type: ScalarType
+    dtype: ScalarType
+
+    def validate(self) -> None:
+        assert isinstance(self.value, (Identifier, ConstantLiteral, Parameter, ArraySlice, UnaryOperator, BinaryOperator))
+        assert isinstance(self.dtype, ScalarType)
 
     def as_ir(self, indent: int = 0) -> str:
         return self.value.as_ir()
@@ -152,63 +161,20 @@ class RangeExpression(SpatialNode):
     """
     A range expression (start:stop or start:stop:step).
     """
-    start: 'Expression'
-    stop: 'Expression'
-    step: 'Expression' = None
+    start: Expression
+    stop: Expression
+    step: Expression = None
+
+    def validate(self) -> None:
+        assert isinstance(self.start, Expression)
+        assert isinstance(self.stop, Expression)
+        if self.step:
+            assert isinstance(self.step, Expression)
 
     def as_ir(self, indent: int = 0) -> str:
         if self.step:
             return f'{self.start.as_ir()}:{self.stop.as_ir()}:{self.step.as_ir()}'
         return f'{self.start.as_ir()}:{self.stop.as_ir()}'
-
-
-@dataclass
-class KernelArgument(SpatialNode):
-    """
-    A kernel argument of a given type.
-    """
-    arg_type: Union[ScalarType, ArrayType, StreamType]
-    name: str
-    readonly: bool = False
-    writeonly: bool = False
-    compiletime: bool = False
-
-    def as_ir(self, indent: int = 0) -> str:
-        annotations = []
-        if self.readonly:
-            annotations.append('readonly')
-        if self.writeonly:
-            annotations.append('writeonly')
-        if self.compiletime:
-            annotations.append('compiletime')
-        ann_str = " ".join(annotations)
-        if ann_str:
-            return f'{self.arg_type.as_ir()} {ann_str} {self.name}'
-        return f'{self.arg_type.as_ir()} {self.name}'
-
-
-@dataclass
-class Kernel(SpatialNode):
-    """
-    A kernel definition.
-    """
-    name: str | None
-    parameters: list[Parameter]
-    arguments: list[KernelArgument]
-    body: list[SpatialNode]
-
-    def validate(self) -> None:
-        assert all(isinstance(p, Parameter) for p in self.parameters)
-        assert all(isinstance(arg, KernelArgument) for arg in self.arguments)
-        assert all(isinstance(stmt, (Phase, ComputeBlock, DataflowBlock, PlaceBlock)) for stmt in self.body)
-
-    def as_ir(self, indent: int = 0) -> str:
-        param_str = ", ".join(p.as_ir() for p in self.parameters)
-        arg_str = ", ".join(arg.as_ir() for arg in self.arguments)
-        body_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.body)
-        return f'kernel @{self.name}<{param_str}>({arg_str}) {{\n{body_str}\n}}' if self.name \
-            else f'kernel<{param_str}>({arg_str}) {{\n{body_str}\n}}'
-
 
 @dataclass
 class SubgridExpression(SpatialNode):
@@ -228,11 +194,15 @@ class FieldDeclaration(SpatialNode):
     Field declaration inside a place block.
     Can be either a scalar or an array.
     """
-    field_type: Union[ScalarType, ArrayType]
+    dtype: Union[ScalarType, ArrayType]
     field_name: Identifier
 
+    def validate(self) -> None:
+        assert isinstance(self.dtype, (ScalarType, ArrayType))
+        assert isinstance(self.field_name, Identifier)
+
     def as_ir(self, indent: int = 0) -> str:
-        return f'{self.field_type.as_ir()} {self.field_name.as_ir()}'
+        return f'{self.dtype.as_ir()} {self.field_name.as_ir()}'
 
 ###
 # Place Block
@@ -242,7 +212,6 @@ class PlaceBlock(SpatialNode):
     """
     The 'place' block for allocating variables or arrays on a subgrid of PEs.
     """
-    variable_type: ScalarType
     variables: list[Identifier]
     subgrid: SubgridExpression
     statements: list[FieldDeclaration]
@@ -250,7 +219,14 @@ class PlaceBlock(SpatialNode):
     def as_ir(self, indent: int = 0) -> str:
         vars_str = ", ".join(v.as_ir() for v in self.variables)
         stmt_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.statements)
-        return f'place {self.variable_type.as_ir()} {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n}}'
+        return f'place {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n}}'
+
+@dataclass
+class RoutingHop(SpatialNode):
+    offset = Tuple[int, int]
+
+    def as_ir(self, indent: int = 0) -> str:
+        return f'({self.offset[0]}, {self.offset[1]})'
 
 
 @dataclass
@@ -258,8 +234,8 @@ class RoutingDeclaration(SpatialNode):
     """
     A routing declaration for a stream, optionally specifying hops and channel.
     """
-    hops: Union[list[Tuple[int, int]], str] = "auto"  # list of hops or 'auto'
-    channel: Union[int, str] = "auto"  # Channel ID or 'auto'
+    hops: Union[list[RoutingHop], Literal["auto"]] = "auto"  # list of hops or 'auto'
+    channel: Union[int, Literal["auto"]] = "auto"  # Channel ID or 'auto'
 
     def validate(self) -> None:
         if isinstance(self.hops, list):
@@ -267,7 +243,7 @@ class RoutingDeclaration(SpatialNode):
                 assert abs(dx) + abs(dy) == 1, "Each hop must have an absolute sum of 1."
 
     def as_ir(self, indent: int = 0) -> str:
-        hops_str = "auto" if self.hops == "auto" else f"[{', '.join(f'({dx}, {dy})' for dx, dy in self.hops)}]"
+        hops_str = "auto" if self.hops == "auto" else f"[{', '.join(hop.as_ir() for hop in self.hops)}]"
         channel_str = "auto" if self.channel == "auto" else str(self.channel)
         return f"hops = {hops_str}, \n{' ' * indent}channel = {channel_str}"
 
@@ -278,7 +254,7 @@ class RelativeStreamDeclaration(SpatialNode):
     A stream declaration inside a dataflow block that declares a communication stream
     to and from PEs at relative positions, with an optional routing declaration.
     """
-    stream_type: StreamType
+    dtype: StreamType
     stream_name: Identifier
     dx: Expression
     dy: Expression
@@ -288,7 +264,7 @@ class RelativeStreamDeclaration(SpatialNode):
         routing_str = ""
         if self.routing:
             routing_str = f" {{\n{self.routing.as_ir(indent + 2)}\n{' ' * indent}}}"
-        return f'stream<{self.stream_type.element_type.as_ir()}> {self.stream_name.as_ir()} = relative_stream({self.dx.as_ir()}, {self.dy.as_ir()}){routing_str}'
+        return f'stream<{self.dtype.element_type.as_ir()}> {self.stream_name.as_ir()} = relative_stream({self.dx.as_ir()}, {self.dy.as_ir()}){routing_str}'
 
 ###
 # Dataflow Block
@@ -457,7 +433,7 @@ class ComputeBlock(SpatialNode):
         return f'compute {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n}}'
 
 ###
-# Phases
+# Phases & Kernels
 ###
 
 @dataclass
@@ -465,14 +441,66 @@ class Phase(SpatialNode):
     """
     Encapsulates a phase of data placement, communication, and computation.
     """
-    placement: list[PlaceBlock]
+    place: list[PlaceBlock]
     dataflow: list[DataflowBlock]
     compute: list[ComputeBlock]
 
     def as_ir(self, indent: int = 0) -> str:
         phase_str = "phase {\n"
-        dataflow_str = "\n".join(df.as_ir(indent + 2) for df in self.dataflows)
-        compute_str = "\n".join(cmp.as_ir(indent + 2) for cmp in self.computes)
-        place_str = "\n".join(pl.as_ir(indent + 2) for pl in self.places)
+        dataflow_str = "\n".join(df.as_ir(indent + 2) for df in self.dataflow)
+        compute_str = "\n".join(cmp.as_ir(indent + 2) for cmp in self.compute)
+        place_str = "\n".join(pl.as_ir(indent + 2) for pl in self.place)
         return f'{phase_str}{dataflow_str}\n{compute_str}\n{place_str}\n{" " * indent}}}'
 
+
+@dataclass
+class KernelArgument(SpatialNode):
+    """
+    A kernel argument of a given type.
+    """
+    dtype: Union[ScalarType, ArrayType, StreamType]
+    identifier: Identifier
+    readonly: bool = False
+    writeonly: bool = False
+    compiletime: bool = False
+
+    def validate(self) -> None:
+        assert isinstance(self.dtype, (ScalarType, ArrayType, StreamType))
+        assert isinstance(self.identifier, Identifier)
+
+    def as_ir(self, indent: int = 0) -> str:
+        annotations = []
+        if self.readonly:
+            annotations.append('readonly')
+        if self.writeonly:
+            annotations.append('writeonly')
+        if self.compiletime:
+            annotations.append('compiletime')
+        ann_str = " ".join(annotations)
+        if ann_str:
+            return f'{self.dtype.as_ir()} {ann_str} {self.identifier.as_ir()}'
+        return f'{self.dtype.as_ir()} {self.identifier.as_ir()}'
+
+
+@dataclass
+class Kernel(SpatialNode):
+    """
+    A kernel definition.
+    """
+    name: str | None
+    parameters: list[Parameter]
+    arguments: list[KernelArgument]
+    body: list[PlaceBlock | DataflowBlock | ComputeBlock | Phase]
+
+    def validate(self) -> None:
+        assert all(isinstance(p, Parameter) for p in self.parameters)
+        assert all(isinstance(arg, KernelArgument) for arg in self.arguments)
+        assert all(isinstance(stmt, (Phase, ComputeBlock, DataflowBlock, PlaceBlock)) for stmt in self.body)
+        assert self.validate_schema()
+
+    def as_ir(self, indent: int = 0) -> str:
+        param_str = ", ".join(p.as_ir() for p in self.parameters)
+        arg_str = ", ".join(arg.as_ir() for arg in self.arguments)
+        body_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.body)
+        return f'kernel @{self.name}<{param_str}>({arg_str}) {{\n{body_str}\n}}' if self.name \
+            else f'kernel<{param_str}>({arg_str}) {{\n{body_str}\n}}'

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -571,7 +571,6 @@ class Kernel(SpatialNode):
         assert all(isinstance(p, Parameter) for p in self.parameters)
         assert all(isinstance(arg, KernelArgument) for arg in self.arguments)
         assert all(isinstance(stmt, (Phase, ComputeBlock, DataflowBlock, PlaceBlock)) for stmt in self.body)
-        assert self.validate_schema()
 
     def as_ir(self, indent: int = 0) -> str:
         param_str = ", ".join(p.as_ir() for p in self.parameters)

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -135,36 +135,18 @@ class ArraySlice(SpatialNode):
         return f'{self.array.as_ir()}[{index_str}]'
 
 
-# Parameter Expressions (integer expressions)
 @dataclass
-class ParameterExpression(SpatialNode):
+class Expression(SpatialNode):
     """
-    An expression involving parameters, constants, and arithmetic operations.
+    A general expression that can take the form of an identifier, literal, array slice, unary/binary operator, etc.
     """
-    expr: Union[ConstantLiteral, Parameter, UnaryOperator, BinaryOperator]
+    value: Union[Identifier, ConstantLiteral, Parameter, ArraySlice, UnaryOperator, BinaryOperator]
+    type: ScalarType
 
     def as_ir(self, indent: int = 0) -> str:
-        return self.expr.as_ir()
+        return self.value.as_ir()
 
 
-# Boolean Expressions
-@dataclass
-class BoolExpression(SpatialNode):
-    """
-    A boolean expression (e.g., x == y).
-    """
-    left: 'Expression'
-    op: str
-    right: 'Expression'
-
-    def validate(self) -> None:
-        assert self.op in ('==', '!=', '<', '<=', '>', '>=')
-
-    def as_ir(self, indent: int = 0) -> str:
-        return f'{self.left.as_ir()} {self.op} {self.right.as_ir()}'
-
-
-# Range Expressions
 @dataclass
 class RangeExpression(SpatialNode):
     """
@@ -180,7 +162,6 @@ class RangeExpression(SpatialNode):
         return f'{self.start.as_ir()}:{self.stop.as_ir()}'
 
 
-# Kernel Arguments
 @dataclass
 class KernelArgument(SpatialNode):
     """
@@ -206,37 +187,29 @@ class KernelArgument(SpatialNode):
         return f'{self.arg_type.as_ir()} {self.name}'
 
 
-# Kernel
 @dataclass
 class Kernel(SpatialNode):
     """
     A kernel definition.
     """
-    name: str
+    name: str | None
     parameters: list[Parameter]
     arguments: list[KernelArgument]
     body: list[SpatialNode]
+
+    def validate(self) -> None:
+        assert all(isinstance(p, Parameter) for p in self.parameters)
+        assert all(isinstance(arg, KernelArgument) for arg in self.arguments)
+        assert all(isinstance(stmt, (Phase, ComputeBlock, DataflowBlock, PlaceBlock)) for stmt in self.body)
 
     def as_ir(self, indent: int = 0) -> str:
         param_str = ", ".join(p.as_ir() for p in self.parameters)
         arg_str = ", ".join(arg.as_ir() for arg in self.arguments)
         body_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.body)
-        return f'kernel {self.name}<{param_str}>({arg_str}) {{\n{body_str}\n}}'
+        return f'kernel @{self.name}<{param_str}>({arg_str}) {{\n{body_str}\n}}' if self.name \
+            else f'kernel<{param_str}>({arg_str}) {{\n{body_str}\n}}'
 
 
-# Expression
-@dataclass
-class Expression(SpatialNode):
-    """
-    A general expression that can take the form of an identifier, literal, array slice, unary/binary operator, etc.
-    """
-    value: Union[Identifier, ConstantLiteral, Parameter, ArraySlice, UnaryOperator, BinaryOperator, BoolExpression]
-
-    def as_ir(self, indent: int = 0) -> str:
-        return self.value.as_ir()
-
-
-# Subgrid Expression (already defined earlier)
 @dataclass
 class SubgridExpression(SpatialNode):
     """
@@ -249,7 +222,6 @@ class SubgridExpression(SpatialNode):
         return f'[{self.x_range.as_ir()} , {self.y_range.as_ir()}]'
 
 
-# Field Declaration (for variables and arrays in place blocks)
 @dataclass
 class FieldDeclaration(SpatialNode):
     """
@@ -262,8 +234,9 @@ class FieldDeclaration(SpatialNode):
     def as_ir(self, indent: int = 0) -> str:
         return f'{self.field_type.as_ir()} {self.field_name.as_ir()}'
 
-
+###
 # Place Block
+###
 @dataclass
 class PlaceBlock(SpatialNode):
     """
@@ -280,7 +253,6 @@ class PlaceBlock(SpatialNode):
         return f'place {self.variable_type.as_ir()} {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n}}'
 
 
-# Routing Declaration for Streams
 @dataclass
 class RoutingDeclaration(SpatialNode):
     """
@@ -300,7 +272,6 @@ class RoutingDeclaration(SpatialNode):
         return f"hops = {hops_str}, \n{' ' * indent}channel = {channel_str}"
 
 
-# Relative Stream Declaration with Optional Routing
 @dataclass
 class RelativeStreamDeclaration(SpatialNode):
     """
@@ -309,18 +280,21 @@ class RelativeStreamDeclaration(SpatialNode):
     """
     stream_type: StreamType
     stream_name: Identifier
-    dx: ParameterExpression
-    dy: ParameterExpression
+    dx: Expression
+    dy: Expression
     routing: Optional[RoutingDeclaration] = None
 
     def as_ir(self, indent: int = 0) -> str:
         routing_str = ""
         if self.routing:
             routing_str = f" {{\n{self.routing.as_ir(indent + 2)}\n{' ' * indent}}}"
-        return (f'stream<{self.stream_type.element_type.as_ir()}> {self.stream_name.as_ir()} = relative_stream({self.dx.as_ir()}, {self.dy.as_ir()}){routing_str}')
+        return f'stream<{self.stream_type.element_type.as_ir()}> {self.stream_name.as_ir()} = relative_stream({self.dx.as_ir()}, {self.dy.as_ir()}){routing_str}'
 
-
+###
 # Dataflow Block
+###
+
+
 @dataclass
 class DataflowBlock(SpatialNode):
     """
@@ -335,6 +309,9 @@ class DataflowBlock(SpatialNode):
         stmt_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.statements)
         return f'dataflow {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n}}'
 
+###
+# Compute Block
+###
 
 # Base class for all statements in the compute block
 @dataclass
@@ -479,6 +456,9 @@ class ComputeBlock(SpatialNode):
         stmt_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.statements)
         return f'compute {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n}}'
 
+###
+# Phases
+###
 
 @dataclass
 class Phase(SpatialNode):

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import List, Union, Tuple, Optional
 from spatialstencil.syntax.common.basenode import BaseNode
-from spatialstencil.syntax.common.types import ScalarType
+from spatialstencil.syntax.common.types import ScalarType, IRType
 
 
 @dataclass
@@ -34,6 +34,7 @@ class Parameter(SpatialNode):
     A parameter literal (e.g., I, J, K).
     """
     name: str
+    value: Optional[int] = None
 
     def as_ir(self, indent: int = 0) -> str:
         return self.name
@@ -54,7 +55,7 @@ class Identifier(SpatialNode):
 
 # Streams
 @dataclass
-class StreamType(SpatialNode):
+class StreamType(SpatialNode, IRType):
     """
     A stream type that sends elements of type T.
     """
@@ -66,7 +67,7 @@ class StreamType(SpatialNode):
 
 # Arrays
 @dataclass
-class ArrayType(SpatialNode):
+class ArrayType(SpatialNode, IRType):
     """
     An array type of a scalar or stream, with one or more dimensions.
     """

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -1,0 +1,478 @@
+from dataclasses import dataclass
+from typing import List, Union, Tuple, Optional
+from spatialstencil.syntax.common.basenode import BaseNode
+from spatialstencil.syntax.common.types import ScalarType
+
+
+@dataclass
+class SpatialNode(BaseNode):
+    """
+    Base class for all spatial IR nodes.
+    """
+    def as_ir(self, indent: int = 0) -> str:
+        raise NotImplementedError()
+
+
+
+# Constant Literals
+@dataclass
+class ConstantLiteral(SpatialNode):
+    """
+    A constant literal (e.g., 0, 1, -12).
+    """
+    value: Union[int, float]
+    type: ScalarType
+
+    def as_ir(self, indent: int = 0) -> str:
+        return str(self.value)
+
+
+# Parameters
+@dataclass
+class Parameter(SpatialNode):
+    """
+    A parameter literal (e.g., I, J, K).
+    """
+    name: str
+
+    def as_ir(self, indent: int = 0) -> str:
+        return self.name
+
+
+# Variables
+@dataclass
+class Identifier(SpatialNode):
+    """
+    A variable identifier (e.g., x, y, my_variable).
+    """
+    name: str
+    version: int
+
+    def as_ir(self, indent: int = 0) -> str:
+        return f'{self.name}#{self.version}'
+
+
+# Streams
+@dataclass
+class StreamType(SpatialNode):
+    """
+    A stream type that sends elements of type T.
+    """
+    element_type: ScalarType
+
+    def as_ir(self, indent: int = 0) -> str:
+        return f'stream<{self.element_type.as_ir()}>'
+
+
+# Arrays
+@dataclass
+class ArrayType(SpatialNode):
+    """
+    An array type of a scalar or stream, with one or more dimensions.
+    """
+    base_type: Union[ScalarType, StreamType]
+    dimensions: List[Union[int, Parameter]]
+
+    def as_ir(self, indent: int = 0) -> str:
+        dims = ", ".join(str(dim.as_ir() if isinstance(dim, SpatialNode) else dim) for dim in self.dimensions)
+        return f'{self.base_type.as_ir()}[{dims}]'
+
+
+# Unary Operators
+@dataclass
+class UnaryOperator(SpatialNode):
+    """
+    A unary operator (+x, -x).
+    """
+    op: str
+    value: 'Expression'
+
+    def validate(self) -> None:
+        assert self.op in ('+', '-')
+
+    def as_ir(self, indent: int = 0) -> str:
+        return f'{self.op}{self.value.as_ir()}'
+
+
+# Binary Operators
+@dataclass
+class BinaryOperator(SpatialNode):
+    """
+    A binary operator (e.g., x + y, x - y).
+    """
+    left: 'Expression'
+    op: str
+    right: 'Expression'
+
+    def validate(self) -> None:
+        assert self.op in ('+', '-', '*', '/', '//', '%', '==', '!=', '<', '<=', '>', '>=')
+
+    def as_ir(self, indent: int = 0) -> str:
+        return f'{self.left.as_ir()} {self.op} {self.right.as_ir()}'
+
+
+# ArraySlice to handle both subscripts (single index access) and array slices (start:end)
+@dataclass
+class ArraySlice(SpatialNode):
+    """
+    Represents a subscript or slice of an array.
+    For single index access: array[i]
+    For range access: array[start:end]
+    """
+    array: Identifier
+    indices: List[Union[int, Identifier, 'RangeExpression']]  # Handles single-index or ranges
+
+    def as_ir(self, indent: int = 0) -> str:
+        index_strs = []
+        for idx in self.indices:
+            if isinstance(idx, RangeExpression):
+                index_strs.append(idx.as_ir())
+            elif isinstance(idx, Identifier) or isinstance(idx, int):
+                index_strs.append(str(idx))
+        index_str = ", ".join(index_strs)
+        return f'{self.array.as_ir()}[{index_str}]'
+
+
+# Parameter Expressions (integer expressions)
+@dataclass
+class ParameterExpression(SpatialNode):
+    """
+    An expression involving parameters, constants, and arithmetic operations.
+    """
+    expr: Union[ConstantLiteral, Parameter, UnaryOperator, BinaryOperator]
+
+    def as_ir(self, indent: int = 0) -> str:
+        return self.expr.as_ir()
+
+
+# Boolean Expressions
+@dataclass
+class BoolExpression(SpatialNode):
+    """
+    A boolean expression (e.g., x == y).
+    """
+    left: 'Expression'
+    op: str
+    right: 'Expression'
+
+    def validate(self) -> None:
+        assert self.op in ('==', '!=', '<', '<=', '>', '>=')
+
+    def as_ir(self, indent: int = 0) -> str:
+        return f'{self.left.as_ir()} {self.op} {self.right.as_ir()}'
+
+
+# Range Expressions
+@dataclass
+class RangeExpression(SpatialNode):
+    """
+    A range expression (start:stop or start:stop:step).
+    """
+    start: 'Expression'
+    stop: 'Expression'
+    step: 'Expression' = None
+
+    def as_ir(self, indent: int = 0) -> str:
+        if self.step:
+            return f'{self.start.as_ir()}:{self.stop.as_ir()}:{self.step.as_ir()}'
+        return f'{self.start.as_ir()}:{self.stop.as_ir()}'
+
+
+# Kernel Arguments
+@dataclass
+class KernelArgument(SpatialNode):
+    """
+    A kernel argument of a given type.
+    """
+    arg_type: Union[ScalarType, ArrayType, StreamType]
+    name: str
+    readonly: bool = False
+    writeonly: bool = False
+    compiletime: bool = False
+
+    def as_ir(self, indent: int = 0) -> str:
+        annotations = []
+        if self.readonly:
+            annotations.append('readonly')
+        if self.writeonly:
+            annotations.append('writeonly')
+        if self.compiletime:
+            annotations.append('compiletime')
+        ann_str = " ".join(annotations)
+        if ann_str:
+            return f'{self.arg_type.as_ir()} {ann_str} {self.name}'
+        return f'{self.arg_type.as_ir()} {self.name}'
+
+
+# Kernel
+@dataclass
+class Kernel(SpatialNode):
+    """
+    A kernel definition.
+    """
+    name: str
+    parameters: List[Parameter]
+    arguments: List[KernelArgument]
+    body: List['Expression']
+
+    def as_ir(self, indent: int = 0) -> str:
+        param_str = ", ".join(p.as_ir() for p in self.parameters)
+        arg_str = ", ".join(arg.as_ir() for arg in self.arguments)
+        body_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.body)
+        return f'kernel {self.name}<{param_str}>({arg_str}) {{\n{body_str}\n}}'
+
+
+# Expression
+@dataclass
+class Expression(SpatialNode):
+    """
+    A general expression that can take the form of an identifier, literal, subscript, unary/binary operator, etc.
+    """
+    value: Union[Identifier, ConstantLiteral, Parameter, ArraySlice, UnaryOperator, BinaryOperator, BoolExpression]
+
+    def as_ir(self, indent: int = 0) -> str:
+        return self.value.as_ir()
+
+
+# Subgrid Expression (already defined earlier)
+@dataclass
+class SubgridExpression(SpatialNode):
+    """
+    A subgrid expression defines the subgrid of PEs to be used in a place or dataflow block.
+    """
+    x_range: RangeExpression
+    y_range: RangeExpression
+
+    def as_ir(self, indent: int = 0) -> str:
+        return f'[{self.x_range.as_ir()} , {self.y_range.as_ir()}]'
+
+
+# Field Declaration (for variables and arrays in place blocks)
+@dataclass
+class FieldDeclaration(SpatialNode):
+    """
+    Field declaration inside a place block.
+    Can be either a scalar or an array.
+    """
+    field_type: Union[ScalarType, ArrayType]
+    field_name: Identifier
+
+    def as_ir(self, indent: int = 0) -> str:
+        return f'{self.field_type.as_ir()} {self.field_name.as_ir()};'
+
+
+# Place Block
+@dataclass
+class PlaceBlock(SpatialNode):
+    """
+    The 'place' block for allocating variables or arrays on a subgrid of PEs.
+    """
+    variable_type: ScalarType
+    variables: List[Identifier]
+    subgrid: SubgridExpression
+    statements: List[FieldDeclaration]
+
+    def as_ir(self, indent: int = 0) -> str:
+        vars_str = ", ".join(v.as_ir() for v in self.variables)
+        stmt_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.statements)
+        return f'place {self.variable_type.as_ir()} {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n}}'
+
+
+# Routing Declaration for Streams
+@dataclass
+class RoutingDeclaration(SpatialNode):
+    """
+    A routing declaration for a stream, optionally specifying hops and channel.
+    """
+    hops: Union[List[Tuple[int, int]], str] = "auto"  # List of hops or 'auto'
+    channel: Union[int, str] = "auto"  # Channel ID or 'auto'
+
+    def validate(self) -> None:
+        if isinstance(self.hops, list):
+            for dx, dy in self.hops:
+                assert abs(dx) + abs(dy) == 1, "Each hop must have an absolute sum of 1."
+
+    def as_ir(self, indent: int = 0) -> str:
+        hops_str = "auto" if self.hops == "auto" else f"[{', '.join(f'({dx}, {dy})' for dx, dy in self.hops)}]"
+        channel_str = "auto" if self.channel == "auto" else str(self.channel)
+        return f"hops = {hops_str};\n{' ' * indent}channel = {channel_str};"
+
+
+# Relative Stream Declaration with Optional Routing
+@dataclass
+class RelativeStreamDeclaration(SpatialNode):
+    """
+    A stream declaration inside a dataflow block that declares a communication stream
+    to and from PEs at relative positions, with an optional routing declaration.
+    """
+    stream_type: StreamType
+    stream_name: Identifier
+    dx: ParameterExpression
+    dy: ParameterExpression
+    routing: Optional[RoutingDeclaration] = None
+
+    def as_ir(self, indent: int = 0) -> str:
+        routing_str = ""
+        if self.routing:
+            routing_str = f" {{\n{self.routing.as_ir(indent + 2)}\n{' ' * indent}}}"
+        return f'stream<{self.stream_type.element_type.as_ir()}> {self.stream_name.as_ir()} = relative_stream({self.dx.as_ir()}, {self.dy.as_ir()}){routing_str};'
+
+
+# Dataflow Block
+@dataclass
+class DataflowBlock(SpatialNode):
+    """
+    The 'dataflow' block for describing communication streams between PEs.
+    """
+    variables: List[Identifier]
+    subgrid: SubgridExpression
+    statements: List[RelativeStreamDeclaration]
+
+    def as_ir(self, indent: int = 0) -> str:
+        vars_str = ", ".join(v.as_ir() for v in self.variables)
+        stmt_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.statements)
+        return f'dataflow {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n}}'
+
+
+# Base class for all statements in the compute block
+@dataclass
+class Statement(SpatialNode):
+    """
+    Base class for all statements in a compute block.
+    """
+    pass
+
+
+# Completion Handle for Asynchronous Operations
+@dataclass
+class Completion(SpatialNode):
+    """
+    Represents a completion handle for asynchronous operations in a compute block.
+    """
+    name: Identifier
+
+    def as_ir(self, indent: int = 0) -> str:
+        return f'completion {self.name.as_ir()}'
+
+
+# Send Statement
+@dataclass
+class SendStatement(Statement):
+    """
+    Send statement for sending data asynchronously through a stream.
+    """
+    local_array: Union[Identifier, ArraySlice]
+    stream_name: Identifier
+    completion_name: Optional[Completion] = None
+
+    def as_ir(self, indent: int = 0) -> str:
+        if self.completion_name:
+            return f'{self.completion_name.as_ir()} = send({self.local_array.as_ir()}, {self.stream_name.as_ir()});'
+        return f'send({self.local_array.as_ir()}, {self.stream_name.as_ir()});'
+
+
+# Receive Statement
+@dataclass
+class ReceiveStatement(SpatialNode):
+    """
+    Receive data from a stream.
+    """
+    stream_name: Identifier
+
+    def as_ir(self, indent: int = 0) -> str:
+        return f'receive({self.stream_name.as_ir()})'
+
+
+# Foreach Loop (asynchronous)
+@dataclass
+class ForeachStatement(Statement):
+    """
+    Foreach loop for asynchronously iterating over a received stream.
+    """
+    variables: List[Identifier]
+    receive_stream: ReceiveStatement
+    body: List[Statement]
+    completion_name: Optional[Completion] = None
+    parameter_range: Optional[RangeExpression] = None
+
+    def as_ir(self, indent: int = 0) -> str:
+        vars_str = ", ".join(var.as_ir() for var in self.variables)
+        body_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.body)
+        if self.parameter_range:
+            return f'{self.completion_name.as_ir()} = foreach {vars_str} in [{self.parameter_range.as_ir()}, {self.receive_stream.as_ir()}] {{\n{body_str}\n{" " * indent}}}'
+        return f'{self.completion_name.as_ir()} = foreach {vars_str} in [{self.receive_stream.as_ir()}] {{\n{body_str}\n{" " * indent}}}'
+
+
+# Map Statement (asynchronous)
+@dataclass
+class MapStatement(Statement):
+    """
+    Map statement for applying an affine computation asynchronously to array elements.
+    """
+    variables: List[Identifier]
+    range_expression: RangeExpression
+    body: List[Statement]
+    completion_name: Optional[Completion] = None
+
+    def as_ir(self, indent: int = 0) -> str:
+        vars_str = ", ".join(var.as_ir() for var in self.variables)
+        body_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.body)
+        return f'{self.completion_name.as_ir()} = map {vars_str} in [{self.range_expression.as_ir()}] {{\n{body_str}\n{" " * indent}}}'
+
+
+# Sequential For Loop
+@dataclass
+class ForStatement(Statement):
+    """
+    Sequential for loop for iterating over a range expression.
+    """
+    variables: List[Identifier]
+    range_expression: RangeExpression
+    body: List[Statement]
+
+    def as_ir(self, indent: int = 0) -> str:
+        vars_str = ", ".join(var.as_ir() for var in self.variables)
+        body_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.body)
+        return f'for {vars_str} in [{self.range_expression.as_ir()}] {{\n{body_str}\n{" " * indent}}}'
+
+
+# Asynchronous Block
+@dataclass
+class AsyncBlock(Statement):
+    """
+    Asynchronous block for executing a computation asynchronously.
+    """
+    body: List[Statement]
+    completion_name: Optional[Completion] = None
+
+    def as_ir(self, indent: int = 0) -> str:
+        body_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.body)
+        return f'{self.completion_name.as_ir()} = async {{\n{body_str}\n{" " * indent}}}'
+
+
+# Await Completion Statement
+@dataclass
+class AwaitStatement(Statement):
+    """
+    Await statement to wait for a completion.
+    """
+    completion_name: Completion
+
+    def as_ir(self, indent: int = 0) -> str:
+        return f'await {self.completion_name.as_ir()};'
+
+
+# Compute Block
+@dataclass
+class ComputeBlock(SpatialNode):
+    """
+    The 'compute' block for defining computation on a subgrid of PEs.
+    """
+    variables: List[Identifier]
+    subgrid: SubgridExpression
+    statements: List[Statement]
+
+    def as_ir(self, indent: int = 0) -> str:
+        vars_str = ", ".join(var.as_ir() for var in self.variables)
+        stmt_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.statements)
+        return f'compute {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n}}'

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -257,7 +257,7 @@ class RoutingDeclaration(SpatialNode):
         indent_str = '  ' * indent
         hops_str = "auto" if self.hops == "auto" else f"[{', '.join(hop.as_ir() for hop in self.hops)}]"
         channel_str = "auto" if self.channel == "auto" else str(self.channel)
-        return f"{indent_str}hops = {hops_str}, \n{indent_str}channel = {channel_str}"
+        return f"{indent_str}hops = {hops_str},\n{indent_str}channel = {channel_str}"
 
 
 @dataclass

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -9,9 +9,9 @@ class SpatialNode(BaseNode):
     """
     Base class for all spatial IR nodes.
     """
+
     def as_ir(self, indent: int = 0) -> str:
         raise NotImplementedError()
-
 
 
 # Constant Literals
@@ -154,7 +154,8 @@ class Expression(SpatialNode):
     dtype: ScalarType
 
     def validate(self) -> None:
-        assert isinstance(self.value, (Identifier, ConstantLiteral, Parameter, ArraySlice, UnaryOperator, BinaryOperator))
+        assert isinstance(self.value,
+                          (Identifier, ConstantLiteral, Parameter, ArraySlice, UnaryOperator, BinaryOperator))
         assert isinstance(self.dtype, ScalarType)
 
     def as_ir(self, indent: int = 0) -> str:
@@ -180,6 +181,7 @@ class RangeExpression(SpatialNode):
         if self.step:
             return f'{self.start.as_ir()}:{self.stop.as_ir()}:{self.step.as_ir()}'
         return f'{self.start.as_ir()}:{self.stop.as_ir()}'
+
 
 @dataclass
 class SubgridExpression(SpatialNode):
@@ -210,6 +212,7 @@ class FieldDeclaration(SpatialNode):
         indent_str = '  ' * indent
         return f'{indent_str}{self.dtype.as_ir()} {self.field_name.as_ir()}'
 
+
 ###
 # Place Block
 ###
@@ -227,6 +230,7 @@ class PlaceBlock(SpatialNode):
         vars_str = ", ".join(v.as_ir() for v in self.variables)
         stmt_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.statements)
         return f'{indent_str}place {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n{indent_str}}}'
+
 
 @dataclass
 class RoutingHop(SpatialNode):
@@ -275,6 +279,7 @@ class RelativeStreamDeclaration(SpatialNode):
             routing_str = f" {{\n{self.routing.as_ir(indent + 1)}\n{' ' * indent}}}"
         return f'{indent_str}stream<{self.dtype.element_type.as_ir()}> {self.stream_name.as_ir()} = relative_stream({self.dx.as_ir()}, {self.dy.as_ir()}){routing_str}'
 
+
 ###
 # Dataflow Block
 ###
@@ -300,9 +305,11 @@ class DataflowBlock(SpatialNode):
         stmt_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.statements)
         return f'{indent_str}dataflow {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n{indent_str}}}'
 
+
 ###
 # Compute Block
 ###
+
 
 # Base class for all statements in the compute block
 @dataclass
@@ -449,6 +456,7 @@ class AwaitStatement(Statement):
 
 # Assignment Statement
 
+
 @dataclass
 class AssignmentStatement(Statement):
     """
@@ -487,9 +495,11 @@ class ComputeBlock(SpatialNode):
         stmt_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.statements)
         return f'{indent_str}compute {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n{indent_str}}}'
 
+
 ###
 # Phases & Kernels
 ###
+
 
 @dataclass
 class Phase(SpatialNode):

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -174,7 +174,7 @@ class RangeExpression(SpatialNode):
     def validate(self) -> None:
         assert isinstance(self.start, Expression)
         assert isinstance(self.stop, Expression)
-        if self.step:
+        if self.step is not None:
             assert isinstance(self.step, Expression)
 
     def as_ir(self, indent: int = 0) -> str:

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -202,7 +202,8 @@ class FieldDeclaration(SpatialNode):
         assert isinstance(self.field_name, Identifier)
 
     def as_ir(self, indent: int = 0) -> str:
-        return f'{self.dtype.as_ir()} {self.field_name.as_ir()}'
+        indent_str = '  ' * indent
+        return f'{indent_str}{self.dtype.as_ir()} {self.field_name.as_ir()}'
 
 ###
 # Place Block
@@ -217,9 +218,10 @@ class PlaceBlock(SpatialNode):
     statements: list[FieldDeclaration]
 
     def as_ir(self, indent: int = 0) -> str:
+        indent_str = '  ' * indent
         vars_str = ", ".join(v.as_ir() for v in self.variables)
-        stmt_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.statements)
-        return f'place {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n}}'
+        stmt_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.statements)
+        return f'{indent_str}place {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n{indent_str}}}'
 
 @dataclass
 class RoutingHop(SpatialNode):
@@ -243,9 +245,10 @@ class RoutingDeclaration(SpatialNode):
                 assert abs(dx) + abs(dy) == 1, "Each hop must have an absolute sum of 1."
 
     def as_ir(self, indent: int = 0) -> str:
+        indent_str = '  ' * indent
         hops_str = "auto" if self.hops == "auto" else f"[{', '.join(hop.as_ir() for hop in self.hops)}]"
         channel_str = "auto" if self.channel == "auto" else str(self.channel)
-        return f"hops = {hops_str}, \n{' ' * indent}channel = {channel_str}"
+        return f"{indent_str}hops = {hops_str}, \n{indent_str}channel = {channel_str}"
 
 
 @dataclass
@@ -261,10 +264,11 @@ class RelativeStreamDeclaration(SpatialNode):
     routing: Optional[RoutingDeclaration] = None
 
     def as_ir(self, indent: int = 0) -> str:
+        indent_str = '  ' * indent
         routing_str = ""
         if self.routing:
-            routing_str = f" {{\n{self.routing.as_ir(indent + 2)}\n{' ' * indent}}}"
-        return f'stream<{self.dtype.element_type.as_ir()}> {self.stream_name.as_ir()} = relative_stream({self.dx.as_ir()}, {self.dy.as_ir()}){routing_str}'
+            routing_str = f" {{\n{self.routing.as_ir(indent + 1)}\n{' ' * indent}}}"
+        return f'{indent_str}stream<{self.dtype.element_type.as_ir()}> {self.stream_name.as_ir()} = relative_stream({self.dx.as_ir()}, {self.dy.as_ir()}){routing_str}'
 
 ###
 # Dataflow Block
@@ -281,9 +285,10 @@ class DataflowBlock(SpatialNode):
     statements: list[RelativeStreamDeclaration]
 
     def as_ir(self, indent: int = 0) -> str:
+        indent_str = '  ' * indent
         vars_str = ", ".join(v.as_ir() for v in self.variables)
-        stmt_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.statements)
-        return f'dataflow {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n}}'
+        stmt_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.statements)
+        return f'{indent_str}dataflow {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n{indent_str}}}'
 
 ###
 # Compute Block
@@ -307,7 +312,8 @@ class Completion(SpatialNode):
     name: Identifier
 
     def as_ir(self, indent: int = 0) -> str:
-        return f'completion {self.name.as_ir()}'
+        indent_str = '  ' * indent
+        return f'{indent_str}completion {self.name.as_ir()}'
 
 
 # Send Statement
@@ -321,9 +327,10 @@ class SendStatement(Statement):
     completion_name: Optional[Completion] = None
 
     def as_ir(self, indent: int = 0) -> str:
+        indent_str = '  ' * indent
         if self.completion_name:
-            return f'{self.completion_name.as_ir()} = send({self.local_array.as_ir()}, {self.stream_name.as_ir()})'
-        return f'send({self.local_array.as_ir()}, {self.stream_name.as_ir()})'
+            return f'{indent_str}{self.completion_name.as_ir()} = send({self.local_array.as_ir()}, {self.stream_name.as_ir()})'
+        return f'{indent_str}send({self.local_array.as_ir()}, {self.stream_name.as_ir()})'
 
 
 # Receive Statement
@@ -335,7 +342,8 @@ class Receive(SpatialNode):
     stream_name: Identifier
 
     def as_ir(self, indent: int = 0) -> str:
-        return f'receive({self.stream_name.as_ir()})'
+        indent_str = '  ' * indent
+        return f'{indent_str}receive({self.stream_name.as_ir()})'
 
 
 # Foreach Loop (asynchronous)
@@ -351,11 +359,12 @@ class ForeachStatement(Statement):
     parameter_range: Optional[RangeExpression] = None
 
     def as_ir(self, indent: int = 0) -> str:
+        indent_str = '  ' * indent
         vars_str = ", ".join(var.as_ir() for var in self.variables)
-        body_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.body)
+        body_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.body)
         if self.parameter_range:
-            return f'{self.completion_name.as_ir()} = foreach {vars_str} in [{self.parameter_range.as_ir()}, {self.receive_stream.as_ir()}] {{\n{body_str}\n{" " * indent}}}'
-        return f'{self.completion_name.as_ir()} = foreach {vars_str} in [{self.receive_stream.as_ir()}] {{\n{body_str}\n{" " * indent}}}'
+            return f'{indent_str}{self.completion_name.as_ir()} = foreach {vars_str} in [{self.parameter_range.as_ir()}, {self.receive_stream.as_ir()}] {{\n{body_str}\n{indent_str}}}'
+        return f'{indent_str}{self.completion_name.as_ir()} = foreach {vars_str} in [{self.receive_stream.as_ir()}] {{\n{body_str}\n{indent_str}}}'
 
 
 # Map Statement (asynchronous)
@@ -370,9 +379,10 @@ class MapStatement(Statement):
     completion_name: Optional[Completion] = None
 
     def as_ir(self, indent: int = 0) -> str:
+        indent_str = '  ' * indent
         vars_str = ", ".join(var.as_ir() for var in self.variables)
-        body_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.body)
-        return f'{self.completion_name.as_ir()} = map {vars_str} in [{self.range_expression.as_ir()}] {{\n{body_str}\n{" " * indent}}}'
+        body_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.body)
+        return f'{indent_str}{self.completion_name.as_ir()} = map {vars_str} in [{self.range_expression.as_ir()}] {{\n{body_str}\n{indent_str}}}'
 
 
 # Sequential For Loop
@@ -386,9 +396,10 @@ class ForStatement(Statement):
     body: list[Statement]
 
     def as_ir(self, indent: int = 0) -> str:
+        indent_str = '  ' * indent
         vars_str = ", ".join(var.as_ir() for var in self.variables)
-        body_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.body)
-        return f'for {vars_str} in [{self.range_expression.as_ir()}] {{\n{body_str}\n{" " * indent}}}'
+        body_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.body)
+        return f'{indent_str}for {vars_str} in [{self.range_expression.as_ir()}] {{\n{body_str}\n{indent_str}}}'
 
 
 # Asynchronous Block
@@ -401,8 +412,9 @@ class AsyncBlock(Statement):
     completion_name: Optional[Completion] = None
 
     def as_ir(self, indent: int = 0) -> str:
-        body_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.body)
-        return f'{self.completion_name.as_ir()} = async {{\n{body_str}\n{" " * indent}}}'
+        indent_str = '  ' * indent
+        body_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.body)
+        return f'{indent_str}{self.completion_name.as_ir()} = async {{\n{body_str}\n{indent_str}}}'
 
 
 # Await Completion Statement
@@ -414,7 +426,8 @@ class AwaitStatement(Statement):
     completion: Completion
 
     def as_ir(self, indent: int = 0) -> str:
-        return f'await {self.completion.as_ir()}'
+        indent_str = '  ' * indent
+        return f'{indent_str}await {self.completion.as_ir()}'
 
 
 # Compute Block
@@ -428,9 +441,10 @@ class ComputeBlock(SpatialNode):
     statements: list[Statement]
 
     def as_ir(self, indent: int = 0) -> str:
+        indent_str = '  ' * indent
         vars_str = ", ".join(var.as_ir() for var in self.variables)
-        stmt_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.statements)
-        return f'compute {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n}}'
+        stmt_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.statements)
+        return f'{indent_str}compute {vars_str} in {self.subgrid.as_ir()} {{\n{stmt_str}\n{indent_str}}}'
 
 ###
 # Phases & Kernels
@@ -446,11 +460,21 @@ class Phase(SpatialNode):
     compute: list[ComputeBlock]
 
     def as_ir(self, indent: int = 0) -> str:
+        indent_str = '  ' * indent
         phase_str = "phase {\n"
-        dataflow_str = "\n".join(df.as_ir(indent + 2) for df in self.dataflow)
-        compute_str = "\n".join(cmp.as_ir(indent + 2) for cmp in self.compute)
-        place_str = "\n".join(pl.as_ir(indent + 2) for pl in self.place)
-        return f'{phase_str}{dataflow_str}\n{compute_str}\n{place_str}\n{" " * indent}}}'
+        dataflow_str = "\n".join(df.as_ir(indent + 1) for df in self.dataflow)
+        compute_str = "\n".join(cmp.as_ir(indent + 1) for cmp in self.compute)
+        place_str = "\n".join(pl.as_ir(indent + 1) for pl in self.place)
+
+        body_str = ""
+        if dataflow_str:
+            body_str += f'{dataflow_str}\n'
+        if compute_str:
+            body_str += f'{compute_str}\n'
+        if place_str:
+            body_str += f'{place_str}\n'
+
+        return f'{indent_str}{phase_str}{body_str}{indent_str}}}'
 
 
 @dataclass
@@ -501,6 +525,6 @@ class Kernel(SpatialNode):
     def as_ir(self, indent: int = 0) -> str:
         param_str = ", ".join(p.as_ir() for p in self.parameters)
         arg_str = ", ".join(arg.as_ir() for arg in self.arguments)
-        body_str = "\n".join(stmt.as_ir(indent + 2) for stmt in self.body)
+        body_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.body)
         return f'kernel @{self.name}<{param_str}>({arg_str}) {{\n{body_str}\n}}' if self.name \
             else f'kernel<{param_str}>({arg_str}) {{\n{body_str}\n}}'

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -72,15 +72,15 @@ class ArrayType(SpatialNode, IRType):
     An array type of a scalar or stream, with one or more dimensions.
     """
     base_type: Union[ScalarType, StreamType]
-    dimensions: list[Union[int, Parameter]]
+    shape: list[Union[int, Parameter]]
 
     def validate(self) -> None:
-        assert isinstance(self.dimensions, list)
-        assert all(isinstance(dim, (int, Parameter)) for dim in self.dimensions)
-        assert len(self.dimensions) > 0
+        assert isinstance(self.shape, list)
+        assert all(isinstance(dim, (int, Parameter)) for dim in self.shape)
+        assert len(self.shape) > 0
 
     def as_ir(self, indent: int = 0) -> str:
-        dims = ", ".join(str(dim.as_ir() if isinstance(dim, SpatialNode) else dim) for dim in self.dimensions)
+        dims = ", ".join(str(dim.as_ir() if isinstance(dim, SpatialNode) else dim) for dim in self.shape)
         return f'{self.base_type.as_ir()}[{dims}]'
 
 
@@ -129,12 +129,17 @@ class ArraySlice(SpatialNode):
     array: Identifier
     indices: list[Union[int, Identifier, 'RangeExpression']]  # Handles single-index or ranges
 
+    def validate(self) -> None:
+        assert isinstance(self.array, Identifier)
+        assert isinstance(self.indices, list)
+        assert all(isinstance(idx, (int, Identifier, RangeExpression)) for idx in self.indices)
+
     def as_ir(self, indent: int = 0) -> str:
         index_strs = []
         for idx in self.indices:
-            if isinstance(idx, RangeExpression):
+            if isinstance(idx, (RangeExpression, Identifier)):
                 index_strs.append(idx.as_ir())
-            elif isinstance(idx, Identifier) or isinstance(idx, int):
+            elif isinstance(idx, int):
                 index_strs.append(str(idx))
         index_str = ", ".join(index_strs)
         return f'{self.array.as_ir()}[{index_str}]'
@@ -284,6 +289,11 @@ class DataflowBlock(SpatialNode):
     subgrid: SubgridExpression
     statements: list[RelativeStreamDeclaration]
 
+    def validate(self) -> None:
+        assert all(isinstance(var, Identifier) for var in self.variables)
+        assert all(isinstance(stmt, RelativeStreamDeclaration) for stmt in self.statements)
+        assert len(self.variables) == 2
+
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
         vars_str = ", ".join(v.as_ir() for v in self.variables)
@@ -362,9 +372,16 @@ class ForeachStatement(Statement):
         indent_str = '  ' * indent
         vars_str = ", ".join(var.as_ir() for var in self.variables)
         body_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.body)
+
         if self.parameter_range:
-            return f'{indent_str}{self.completion_name.as_ir()} = foreach {vars_str} in [{self.parameter_range.as_ir()}, {self.receive_stream.as_ir()}] {{\n{body_str}\n{indent_str}}}'
-        return f'{indent_str}{self.completion_name.as_ir()} = foreach {vars_str} in [{self.receive_stream.as_ir()}] {{\n{body_str}\n{indent_str}}}'
+            main_str = f'foreach {vars_str} in [{self.parameter_range.as_ir()}, {self.receive_stream.as_ir()}] {{\n{body_str}\n{indent_str}}}'
+        else:
+            main_str = f'foreach {vars_str} in [{self.receive_stream.as_ir()}] {{\n{body_str}\n{indent_str}}}'
+
+        if self.completion_name:
+            return f'{indent_str}{self.completion_name.as_ir()} = {main_str}'
+        else:
+            return f'{indent_str}await {main_str}'
 
 
 # Map Statement (asynchronous)
@@ -458,6 +475,11 @@ class ComputeBlock(SpatialNode):
     variables: list[Identifier]
     subgrid: SubgridExpression
     statements: list[Statement]
+
+    def validate(self) -> None:
+        assert all(isinstance(var, Identifier) for var in self.variables)
+        assert all(isinstance(stmt, Statement) for stmt in self.statements)
+        assert len(self.variables) == 2
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent

--- a/spatialstencil/syntax/stencil_ir/irnodes.py
+++ b/spatialstencil/syntax/stencil_ir/irnodes.py
@@ -788,7 +788,6 @@ class Program(Node, Operation, Block):
         assert all(isinstance(i, (FieldType, ScalarType, AnyType)) for i in self.operation_type.source)
         assert all(isinstance(i, (FieldType, ScalarType, AnyType)) for i in self.operation_type.destination)
         assert isinstance(self.computations[-1], ReturnOp)
-        assert self.validate_schema()
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent

--- a/spatialstencil/syntax/stencil_ir/irnodes.py
+++ b/spatialstencil/syntax/stencil_ir/irnodes.py
@@ -7,30 +7,8 @@ from typing import Literal, Sequence
 
 from spatialstencil.syntax.common.basenode import BaseNode
 from spatialstencil.syntax.common import visitor
+from spatialstencil.syntax.common.types import IRType, ScalarType
 
-
-class IRType:
-    """
-    Interface that indicates this node represents a type.
-    """
-    pass
-
-
-class ScalarType(enum.Enum):
-    UNKNOWN = enum.auto()  # Not yet type-inferred
-    i8 = enum.auto()
-    i16 = enum.auto()
-    i32 = enum.auto()
-    u8 = enum.auto()
-    u16 = enum.auto()
-    u32 = enum.auto()
-    f16 = enum.auto()
-    f32 = enum.auto()
-    f64 = enum.auto()
-    bool = enum.auto()
-
-    def as_ir(self, indent: int = 0) -> str:
-        return self.name
 
 @dataclass(frozen=True)
 class AnyType(IRType):
@@ -42,28 +20,11 @@ class AnyType(IRType):
         return True
 
 
-BIT_WIDTH = {
-    ScalarType.UNKNOWN: 0,
-    ScalarType.i8: 8,
-    ScalarType.i16: 16,
-    ScalarType.i32: 32,
-    ScalarType.u8: 8,
-    ScalarType.u16: 16,
-    ScalarType.u32: 32,
-    ScalarType.f16: 16,
-    ScalarType.f32: 32,
-    ScalarType.f64: 64,
-    ScalarType.bool: 1,
-}
-
-
 class ComputationType(enum.Enum):
     # We are using numbers to ensure compatibility with GT4Py's AST values
     PARALLEL = 0
     FORWARD = 1
     BACKWARD = 2
-
-
 
 
 class Node(BaseNode):
@@ -86,15 +47,6 @@ class Node(BaseNode):
         :param indent: Indentation for the IR node.
         """
         return str(self)
-
-    def validate(self) -> None:
-        """
-        Runs assertions on the node.
-        """
-        pass
-
-    def __post_init__(self):
-        self.validate()
 
 
 class Domain(Node, IRType):

--- a/spatialstencil/syntax/stencil_ir/irnodes.py
+++ b/spatialstencil/syntax/stencil_ir/irnodes.py
@@ -10,16 +10,6 @@ from spatialstencil.syntax.common import visitor
 from spatialstencil.syntax.common.types import IRType, ScalarType
 
 
-@dataclass(frozen=True)
-class AnyType(IRType):
-
-    def as_ir(self) -> str:
-        return "?"
-
-    def is_unknown(self) -> bool:
-        return True
-
-
 class ComputationType(enum.Enum):
     # We are using numbers to ensure compatibility with GT4Py's AST values
     PARALLEL = 0
@@ -47,6 +37,16 @@ class Node(BaseNode):
         :param indent: Indentation for the IR node.
         """
         return str(self)
+
+
+@dataclass
+class AnyType(Node, IRType):
+
+    def as_ir(self) -> str:
+        return "?"
+
+    def is_unknown(self) -> bool:
+        return True
 
 
 class Domain(Node, IRType):
@@ -788,6 +788,7 @@ class Program(Node, Operation, Block):
         assert all(isinstance(i, (FieldType, ScalarType, AnyType)) for i in self.operation_type.source)
         assert all(isinstance(i, (FieldType, ScalarType, AnyType)) for i in self.operation_type.destination)
         assert isinstance(self.computations[-1], ReturnOp)
+        assert self.validate_schema()
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent

--- a/spatialstencil/syntax/stencil_ir/type_inference.py
+++ b/spatialstencil/syntax/stencil_ir/type_inference.py
@@ -2,6 +2,8 @@
 Contains scalar type inference functionality for the Stencil IR.
 """
 import copy
+
+from spatialstencil.syntax.common import types
 from spatialstencil.syntax.stencil_ir import irnodes as sast
 from spatialstencil.syntax.stencil_ir import analysis
 
@@ -257,21 +259,21 @@ def _result_type_of(*args: sast.ScalarType, optype: str | None = None) -> sast.S
     for arg in args:
         if arg in (sast.ScalarType.f16, sast.ScalarType.f32, sast.ScalarType.f64):
             # Floating point
-            if max_bit_width_float[0] is None or max_bit_width_float[0] < sast.BIT_WIDTH[arg]:
-                max_bit_width_float = sast.BIT_WIDTH[arg], arg
+            if max_bit_width_float[0] is None or max_bit_width_float[0] < types.BIT_WIDTH[arg]:
+                max_bit_width_float = types.BIT_WIDTH[arg], arg
         elif arg in (sast.ScalarType.bool, sast.ScalarType.u8, sast.ScalarType.u16, sast.ScalarType.u32):
             # Unsigned integer
-            if max_bit_width_uint[0] is None or max_bit_width_uint[0] < sast.BIT_WIDTH[arg]:
-                max_bit_width_uint = sast.BIT_WIDTH[arg], arg
+            if max_bit_width_uint[0] is None or max_bit_width_uint[0] < types.BIT_WIDTH[arg]:
+                max_bit_width_uint = types.BIT_WIDTH[arg], arg
         else:
             # Signed integer
-            if max_bit_width_int[0] is None or max_bit_width_int[0] < sast.BIT_WIDTH[arg]:
-                max_bit_width_int = sast.BIT_WIDTH[arg], arg
+            if max_bit_width_int[0] is None or max_bit_width_int[0] < types.BIT_WIDTH[arg]:
+                max_bit_width_int = types.BIT_WIDTH[arg], arg
 
     # Specific math calls make the result floating point
     if optype in ('sqrt', 'cbrt'):
         if max_bit_width_float[0] is None:  # If no floating-point value exists, use other arguments
-            max_bit_width = max(sast.BIT_WIDTH[arg] for arg in args)
+            max_bit_width = max(types.BIT_WIDTH[arg] for arg in args)
             max_bit_width = max(16, max_bit_width)
             max_bit_width_float = max_bit_width, sast.ScalarType[f'f{max_bit_width}']
 

--- a/tests/test_spatial_ir_schema.py
+++ b/tests/test_spatial_ir_schema.py
@@ -1,0 +1,12 @@
+import unittest
+
+from spatialstencil.syntax.spatial_ir.irnodes import Kernel
+
+
+class TestStencilIR(unittest.TestCase):
+    def test_validate_stencil_schema(self):
+        Kernel.validate_schema()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_spatial_ir_schema.py
+++ b/tests/test_spatial_ir_schema.py
@@ -3,7 +3,7 @@ import unittest
 from spatialstencil.syntax.spatial_ir.irnodes import Kernel
 
 
-class TestStencilIR(unittest.TestCase):
+class TestSpatialIR(unittest.TestCase):
     def test_validate_stencil_schema(self):
         Kernel.validate_schema()
 

--- a/tests/test_stencil_ir_schema.py
+++ b/tests/test_stencil_ir_schema.py
@@ -1,0 +1,10 @@
+import unittest
+from spatialstencil.syntax.stencil_ir.irnodes import Program
+
+class TestStencilIR(unittest.TestCase):
+    def test_validate_stencil_schema(self):
+        Program.validate_schema()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Changes to syntax/spatial

* Draft of the Spatial IR Syntax Implementation. 

Note that it is a fairly direct translation of the syntax and does not include any control flow graph notions (yet).

Changes to syntax/common

* Refactor the scalar types into common, so we can reuse them between IRs.
* validate() should be part of the base node.
* I fixed validate_schema to work properly with UnionTypes using Union or | syntax.
* validate_schema is a class method.

Changes in syntax/stencil

* call validate_schema in the Program validate()