### PR TITLE
Spatial IR Harmonization and Parser

### DIFF
--- a/irspec/docs/spatial/async.md
+++ b/irspec/docs/spatial/async.md
@@ -35,7 +35,7 @@ and instead considers the program order.
     ```rust
     // S1
     a[0] = 0;
-    for i in [0:10] {
+    for i16 i in [0:10] {
         // S_2
         a[i] = b[i];
         // S_3
@@ -138,7 +138,7 @@ of the interleaving of concurrent operations.
     // Concurrently writing to and sending from the same array
     // We forbid this because the result of the send would be non-deterministic
     completion c1 = send(a, stream);
-    for k in [0:K] {
+    for i16 k in [0:K] {
         // Data Race!!
         a[k] = k; 
     }
@@ -147,13 +147,13 @@ of the interleaving of concurrent operations.
     // Correctly synchronized, we would get
     completion c1 = send(a, stream);
     await c1;
-    for k in [0:K] {
+    for i16 k in [0:K] {
         a[k] = 1;
     }
     
     // Correctly synchronized with short-hand await syntax
     await send(a, stream);
-    for k in [0:K] {
+    for i16 k in [0:K] {
         a[k] = 1;
     }
     
@@ -175,18 +175,18 @@ of the interleaving of concurrent operations.
       // at 0, wait for receival, then send to 1
       // at 1, on receival update array a
       
-      place i, j in [0:2, 0] {
+      place i16 i, i16 j in [0:2, 0] {
         f32[K] a;
       }
     
-      dataflow i, j in [0:2, 0] {
+      dataflow i16 i, i16 j in [0:2, 0] {
           stream<f32> eastwards = relative_stream(1, 0);
           stream<f32> westwards = relative_stream(-1, 0);
       }
     
-      compute i, j in [0, 0] {
+      compute i16 i, i16 j in [0, 0] {
          // S_1
-         completion c1 = foreach x, k in [receive(eastwards)] {
+         completion c1 = foreach f32 x, i16 k in [receive(eastwards), 0:K] {
             a[k] = 2 * x
          }
          // S_2
@@ -195,13 +195,13 @@ of the interleaving of concurrent operations.
          completion c2 = send(a, westwards);
       }
     
-      compute i, j in [1, 0] {
+      compute i16 i, i16 j in [1, 0] {
          // S_4
          completion c3 = send(a, eastwards);
          // S_5 (data race)
          a[0] = 0;
          // S_6
-         completion c4 = foreach x, k in [receive(westwards)] {
+         completion c4 = foreach f32 x, i16 k in [receive(westwards), 0:K] {
             // S_7 (correctly synchronized)
             a[k] = x;
          }
@@ -232,32 +232,32 @@ of the interleaving of concurrent operations.
     // Example: Sends to the same stream must be synchronized, and receives as well.
     // They may be concurrent with each other
     
-    place i, j in [0:4, 0] {
+    place i16 i, i16 j in [0:4, 0] {
         f32[K] a;
         f32[K] b;
     }
     
-    dataflow i, j in [0:4, 0] {
+    dataflow i16 i, i16 j in [0:4, 0] {
         stream<f32> eastwards = relative_stream(1, 0);
     }
     
-    compute i, j in [0, 0] {
+    compute i16 i, i16 j in [0, 0] {
       // Receive twice:
       // The receives must be synchronized
       // S_1
-      await foreach x, k in [0:K, receive(eastwards)] {
+      await foreach i16 k, f32 x in [0:K, receive(eastwards)] {
           a[k] = x + 1;
       }
       // S_2
-      await foreach x, k in [0:K, receive(eastwards)] {
+      await foreach i16 k, f32 x in [0:K, receive(eastwards)] {
           a[k] = a[k] + x;
       }
     }
     
-    compute i, j in [1:4, 0] {
+    compute i16 i, i16 j in [1:4, 0] {
        // S_3
        // Receive (concurrent with send)
-       completion c2 = foreach x, k in [0:K, receive(eastwards)] {
+       completion c2 = foreach i16 k, f32 x in [0:K, receive(eastwards)] {
           // S_4
           a[k] = x + 1;
        }
@@ -272,7 +272,7 @@ of the interleaving of concurrent operations.
        
        // S_8
        // Receive (concurrent with send)
-       completion c4 = foreach x, k in [0:K, receive(eastwards)] {
+       completion c4 = foreach i16 k, f32 x in [0:K, receive(eastwards)] {
           // S_9
           a[k] = a[k] + x;
        }
@@ -303,18 +303,18 @@ of the interleaving of concurrent operations.
       // at 0, wait for receival, then send to 1
       // at 1, on receival update array a
       
-      place i, j in [0:2, 0] {
+      place i16 i, i16 j in [0:2, 0] {
         f32[K] a;
       }
     
-      dataflow i, j in [0:2, 0] {
+      dataflow i16 i, i16 j in [0:2, 0] {
           stream<f32> eastwards = relative_stream(1, 0);
           stream<f32> westwards = relative_stream(-1, 0);
       }
     
-      compute i, j in [0, 0] {
+      compute i16 i, i16 j in [0, 0] {
          // S_1
-         completion c1 = foreach x, k in [0: K, receive(eastwards)] {
+         completion c1 = foreach i16 k, f32 x in [0:K, receive(eastwards)] {
             a[k] = x;
          }
          // S_2
@@ -324,16 +324,16 @@ of the interleaving of concurrent operations.
     
          // Another ping
          // S_4
-         await foreach x, k in [0: K, receive(eastwards)] {
+         await foreach i16 k, f32 x in [0:K, receive(eastwards)] {
             a[k] = x;
          }
       }
     
-      compute i, j in [1, 0] {
+      compute i16 i, i16 j in [1, 0] {
          // S_5
          completion c3 = send(a, eastwards);
          // S_6
-         completion c4 = foreach x, k in [0: K, receive(westwards)] {
+         completion c4 = foreach i16 k, f32 x in [0:K, receive(westwards)] {
             // S (correctly synchronized)
             a[k] = x;
          }
@@ -374,15 +374,15 @@ of the interleaving of concurrent operations.
     
     
     ```rust
-    place i, j in [0:K, 0] {
+    place i16 i, i16 j in [0:K, 0] {
         f32[K] a;
     }
     
-    dataflow i, j in [0:K, 0] {
+    dataflow i16 i, i16 j in [0:K, 0] {
         stream<f32> eastwards = relative_stream(1, 0);
     }
     
-    compute i, j in [0, 0] {
+    compute i16 i, i16 j in [0, 0] {
         // S_1
         await foreach x, k in [0:K, receive(eastwards)] {
             // S_2
@@ -390,16 +390,16 @@ of the interleaving of concurrent operations.
         }
     }
     
-    compute i, j in [1:K-1, 0] {
+    compute i16 i, i16 j in [1:K-1, 0] {
         // S_3
-        await foreach x, k in [0:K, receive(eastwards)] {
+        await foreach i16 k, f32 x in [0:K, receive(eastwards)] {
             a[k] = a[k] + x;
         }
         // S_4
         completion c1 = send(a, eastwards);
     }
     
-    compute i, j in [K, 0] {
+    compute i16 i, i16 j in [K, 0] {
         // S_5
         completion c1 = send(a, eastwards);
     }
@@ -446,7 +446,7 @@ A [`send`](../spatial#streaming-data-with-send) statement may stall while the re
     stream s1 = relative_stream(1, 0);
     // ...
     await send(a, s1);
-    await foreach x, k in [receive(s1)] {
+    await foreach i16 k, f32 x in [0:K, receive(s1)] {
         a[k] = x;
     }
     ```
@@ -461,13 +461,13 @@ A [`send`](../spatial#streaming-data-with-send) statement may stall while the re
     /// ...
     // at P0:
     await send(a, s1);
-    await foreach x, k in [receive(s2)] {
+    await foreach i16 k, f32 x in [0:K, receive(s2)] {
         a[k] = x;
     }
     // ...
     // at P1:
     await send(a, s2);
-    await foreach x, k in [receive(s1)] {
+    await foreach i16 k, f32 x in [0:K, receive(s1)] {
         a[k] = x;
     }
     ```
@@ -482,10 +482,10 @@ A [`send`](../spatial#streaming-data-with-send) statement may stall while the re
     send(a, s1);
     send(b, s2);
     
-    await foreach x in [receive(s1)] {
+    await foreach f32 x in [receive(s1)] {
         // Process x 
     }
-    await foreach x in [receive(s2)] {
+    await foreach f32 x in [receive(s2)] {
         // Process x
     }
     ```

--- a/irspec/docs/spatial/async.md
+++ b/irspec/docs/spatial/async.md
@@ -186,7 +186,7 @@ of the interleaving of concurrent operations.
     
       compute i16 i, i16 j in [0, 0] {
          // S_1
-         completion c1 = foreach f32 x, i16 k in [receive(eastwards), 0:K] {
+         completion c1 = foreach f32 x, i16 k in receive(eastwards), [0:K] {
             a[k] = 2 * x
          }
          // S_2
@@ -201,7 +201,7 @@ of the interleaving of concurrent operations.
          // S_5 (data race)
          a[0] = 0;
          // S_6
-         completion c4 = foreach f32 x, i16 k in [receive(westwards), 0:K] {
+         completion c4 = foreach f32 x, i16 k in receive(westwards), [0:K] {
             // S_7 (correctly synchronized)
             a[k] = x;
          }
@@ -245,11 +245,11 @@ of the interleaving of concurrent operations.
       // Receive twice:
       // The receives must be synchronized
       // S_1
-      await foreach i16 k, f32 x in [0:K, receive(eastwards)] {
+      await foreach i16 k, f32 x in [0:K], receive(eastwards) {
           a[k] = x + 1;
       }
       // S_2
-      await foreach i16 k, f32 x in [0:K, receive(eastwards)] {
+      await foreach i16 k, f32 x in [0:K], receive(eastwards) {
           a[k] = a[k] + x;
       }
     }
@@ -257,7 +257,7 @@ of the interleaving of concurrent operations.
     compute i16 i, i16 j in [1:4, 0] {
        // S_3
        // Receive (concurrent with send)
-       completion c2 = foreach i16 k, f32 x in [0:K, receive(eastwards)] {
+       completion c2 = foreach i16 k, f32 x in [0:K], receive(eastwards) {
           // S_4
           a[k] = x + 1;
        }
@@ -272,7 +272,7 @@ of the interleaving of concurrent operations.
        
        // S_8
        // Receive (concurrent with send)
-       completion c4 = foreach i16 k, f32 x in [0:K, receive(eastwards)] {
+       completion c4 = foreach i16 k, f32 x in [0:K], receive(eastwards) {
           // S_9
           a[k] = a[k] + x;
        }
@@ -314,7 +314,7 @@ of the interleaving of concurrent operations.
     
       compute i16 i, i16 j in [0, 0] {
          // S_1
-         completion c1 = foreach i16 k, f32 x in [0:K, receive(eastwards)] {
+         completion c1 = foreach i16 k, f32 x in [0:K], receive(eastwards) {
             a[k] = x;
          }
          // S_2
@@ -324,7 +324,7 @@ of the interleaving of concurrent operations.
     
          // Another ping
          // S_4
-         await foreach i16 k, f32 x in [0:K, receive(eastwards)] {
+         await foreach i16 k, f32 x in [0:K], receive(eastwards) {
             a[k] = x;
          }
       }
@@ -333,7 +333,7 @@ of the interleaving of concurrent operations.
          // S_5
          completion c3 = send(a, eastwards);
          // S_6
-         completion c4 = foreach i16 k, f32 x in [0:K, receive(westwards)] {
+         completion c4 = foreach i16 k, f32 x in [0:K], receive(westwards) {
             // S (correctly synchronized)
             a[k] = x;
          }
@@ -384,7 +384,7 @@ of the interleaving of concurrent operations.
     
     compute i16 i, i16 j in [0, 0] {
         // S_1
-        await foreach x, k in [0:K, receive(eastwards)] {
+        await foreach x, k in [0:K], receive(eastwards) {
             // S_2
             a[k] = a[k] + x;
         }
@@ -392,7 +392,7 @@ of the interleaving of concurrent operations.
     
     compute i16 i, i16 j in [1:K-1, 0] {
         // S_3
-        await foreach i16 k, f32 x in [0:K, receive(eastwards)] {
+        await foreach i16 k, f32 x in [0:K], receive(eastwards) {
             a[k] = a[k] + x;
         }
         // S_4
@@ -446,7 +446,7 @@ A [`send`](../spatial#streaming-data-with-send) statement may stall while the re
     stream s1 = relative_stream(1, 0);
     // ...
     await send(a, s1);
-    await foreach i16 k, f32 x in [0:K, receive(s1)] {
+    await foreach i16 k, f32 x in [0:K], receive(s1) {
         a[k] = x;
     }
     ```
@@ -461,13 +461,13 @@ A [`send`](../spatial#streaming-data-with-send) statement may stall while the re
     /// ...
     // at P0:
     await send(a, s1);
-    await foreach i16 k, f32 x in [0:K, receive(s2)] {
+    await foreach i16 k, f32 x in [0:K], receive(s2) {
         a[k] = x;
     }
     // ...
     // at P1:
     await send(a, s2);
-    await foreach i16 k, f32 x in [0:K, receive(s1)] {
+    await foreach i16 k, f32 x in [0:K], receive(s1) {
         a[k] = x;
     }
     ```
@@ -482,10 +482,10 @@ A [`send`](../spatial#streaming-data-with-send) statement may stall while the re
     send(a, s1);
     send(b, s2);
     
-    await foreach f32 x in [receive(s1)] {
+    await foreach f32 x in receive(s1) {
         // Process x 
     }
-    await foreach f32 x in [receive(s2)] {
+    await foreach f32 x in receive(s2) {
         // Process x
     }
     ```

--- a/irspec/docs/spatial/examples.md
+++ b/irspec/docs/spatial/examples.md
@@ -45,19 +45,19 @@ kernel vadv<I,J,K>(stream<f32>[I, J] utens_stage,
     // Copy the data
     
     compute i16 i, i16 j in [0:I, 0:J] {
-        foreach k, x in [0:K, receive(u_stage_c)] {
+        foreach k, x in [0:K], receive(u_stage_c) {
             u_stage_l[k] = x;
         }
-        foreach k, x in [0:K, receive(wcon_c)] {
+        foreach k, x in [0:K], receive(wcon_c) {
             wcon_l[k] = x;
         }
-        foreach k, x in [0:K, receive(u_pos_c)] {
+        foreach k, x in [0:K], receive(u_pos_c) {
             u_pos_l[k] = x;
         }
-        foreach k, x in [0:K, receive(utens_c)] {
+        foreach k, x in [0:K], receive(utens_c) {
             utens_l[k] = x;
         }
-        foreach k, x in [0:K, receive(utens_stage_c)] {
+        foreach k, x in [0:K], receive(utens_stage_c) {
             utens_stage_l[k] = x;
         }
         // Exploits implicit completions at the end of each phase
@@ -102,7 +102,7 @@ kernel vadv<I,J,K>(stream<f32>[I, J] utens_stage,
     compute i16 i, i16 j in [0, 0:J] {
       // Boundary condition
       // ...
-      foreach k, x in [0:K, receive(westwards)] {
+      foreach k, x in [0:K], receive(westwards) {
         // ...
       }
     }
@@ -113,14 +113,14 @@ kernel vadv<I,J,K>(stream<f32>[I, J] utens_stage,
         send(wcon_local[1:K], westwards);
 
         // base of the forward
-        await foreach i32 k, f32 x in [0:1, receive(westwards)] {
+        await foreach i32 k, f32 x in [0:1], receive(westwards) {
             gav[k] = -0.25 * x * wcon_l[k];
             gcv[k] = 0
             // ...
         }
 
         // Forward pass: data movement
-        await foreach i32 k, f32 x in [1:K, receive(westwards)] {
+        await foreach i32 k, f32 x in [1:K], receive(westwards) {
           gav[k] = -0.25 * x * wcon_l[k];
           gcv[k-1] = 0.25 * x * wcon_l[k];
 
@@ -189,7 +189,7 @@ kernel laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
     }
   
     compute i16 i, i16 j in [0:I+2, 0:J+2] {
-      foreach k, x in [0:K, receive(in_field_l)] {
+      foreach k, x in [0:K], receive(in_field_l) {
         local_input[k] = x;
       }
     }
@@ -238,7 +238,7 @@ kernel laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
         
         // Writing to local_result form the map would be considered a data race
         // if we did not await f
-        await foreach i32 k, f32 x in [0:K, receive(westwards)] {
+        await foreach i32 k, f32 x in [0:K], receive(westwards) {
           local_result[k] = local_result[k] - x;
         }
 
@@ -246,7 +246,7 @@ kernel laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
         // is considered a data race.
         // Hence, we need to run one after the other.
         send(local_input, eastwards);
-        await foreach i32 k, f32 x in [0:K, receive(eastwards)] {
+        await foreach i32 k, f32 x in [0:K], receive(eastwards) {
           local_result[k] = local_result[k] - x;
         }
         // ...
@@ -304,10 +304,10 @@ kernel <I, J, K>hdiff(stream<f32>[I, J] readonly in_stream,
         }
         
         compute i16 i, i16 j in [0:I, 0:J] {
-            foreach k, x in [0:K, receive(in_field_l)] {
+            foreach k, x in [0:K], receive(in_field_l) {
                 in_field[k] = x;
             }
-            foreach k, x in [0:K, receive(coeff_l)] {
+            foreach k, x in [0:K], receive(coeff_l) {
                 coeff[k] = x;
             }
         }
@@ -338,7 +338,7 @@ kernel <I, J, K>hdiff(stream<f32>[I, J] readonly in_stream,
         await f;
         
         // Result needed: store in in_field_east
-        await foreach i32 k, f32 x in [0:K, receive(westwards)] {
+        await foreach i32 k, f32 x in [0:K], receive(westwards) {
             in_field_east[k] = x;
         }
         // Then, decrement the lap_field using the stored in_field_east
@@ -351,7 +351,7 @@ kernel <I, J, K>hdiff(stream<f32>[I, J] readonly in_stream,
         comp c2 = send(local_input, eastwards);
         
         // result not needed, decrement directly.
-        await foreach i32 k, f32 x in [0:K, receive(eastwards)] {
+        await foreach i32 k, f32 x in [0:K], receive(eastwards) {
             lap_field[k] = lap_field[k] - x;
         }
         
@@ -377,32 +377,32 @@ kernel <I, J, K>hdiff(stream<f32>[I, J] readonly in_stream,
             
             completion c = send(lap_field, west);
             
-            foreach i32 k, f32 x in [0:K, receive(west)] {
+            foreach i32 k, f32 x in [0:K], receive(west) {
                 res[k] = x - lap_field[k];
             }
             
             await c;
             
             await map i32 k in [0:K] {
-                flx_field[k] = (res[k] * (in_field_east[k] - in_field[k])) <= 0) * res[k];
+                flx_field[k] = ((res[k] * (in_field_east[k] - in_field[k])) <= 0) * res[k];
             }
             
             completion c3 = send(lap_field, north);
             
-            foreach i32 k, f32 y in [0:K, receive(north)] {
+            foreach i32 k, f32 y in [0:K], receive(north) {
                 res[k] = y - lap_field[k];
             }
             
             await c3;
             
             await map i32 k in [0:K] {
-                fly_field[k] = (res[k] * (in_field_south[k] - in_field[k])) <= 0) * res[k];
+                fly_field[k] = ((res[k] * (in_field_south[k] - in_field[k])) <= 0) * res[k];
             }
             
             completion c4 = send(flx_field, flx_field_stream);
 
             // No need to copy the flx_field, can accumulate directly
-            await foreach i32 k, f32 x in [0:K, receive(flx_field_stream)] {
+            await foreach i32 k, f32 x in [0:K], receive(flx_field_stream) {
                 out_field[k] = flx_field[k] - x;
             }
             
@@ -411,7 +411,7 @@ kernel <I, J, K>hdiff(stream<f32>[I, J] readonly in_stream,
             completion c5 = send(fly_field, fly_field_stream);
             
             // No need to copy the fly_field, can accumulate directly
-            await foreach i32 k, f32 y in [0:K, receive(fly_field_stream)] {
+            await foreach i32 k, f32 y in [0:K], receive(fly_field_stream) {
                 out_field[k] = outfield[k] + fly_field[k] - y;
             }
             
@@ -445,7 +445,7 @@ kernel <I, J, K>hdiff(stream<f32>[I, J] readonly in_stream,
             // ...
         }
     }
-    
+}
 
 ```
 
@@ -486,7 +486,7 @@ kernel conv<J>(stream<f32>[J] readonly input,
             // Send the data to the right
             comp_east = send(x, eastwards);
 
-            await foreach i16 k, f32 x2 in [0:1, receive(eastwards)] {
+            await foreach i16 k, f32 x2 in [0:1], receive(eastwards) {
               y = y + x2 * kernel[0];
             }
 
@@ -495,7 +495,7 @@ kernel conv<J>(stream<f32>[J] readonly input,
             // Send the data to the left
             comp_west = send(x, westwards);
 
-            await foreach i16 k, f32 x3 in [0:1, receive(westwards)] {
+            await foreach i16 k, f32 x3 in [0:1], receive(westwards) {
                y = y + x3 * kernel[2];
             }
 
@@ -516,7 +516,7 @@ kernel conv<J>(stream<f32>[J] readonly input,
             // S2
             y = x * kernel[1];
             // S3
-            await foreach i16 x, f32 y in [0:1, receive(westwards)] {
+            await foreach i16 x, f32 y in [0:1], receive(westwards) {
                 // S4
                 y = y + x * kernel[2];
             }

--- a/irspec/docs/spatial/examples.md
+++ b/irspec/docs/spatial/examples.md
@@ -18,7 +18,7 @@ kernel vadv<I,J,K>(stream<f32>[I, J] utens_stage,
 
   // A place block on the outer scope carries data between the input phase
   // and the computation phase.
-  place i, j in [0:I, 0:J] {
+  place i16 i, i16 j in [0:I, 0:J] {
       # Inputs & Outputs arrays
       f32[K] utens_stage_l;
       f32[K] utens_stage_l;
@@ -34,7 +34,7 @@ kernel vadv<I,J,K>(stream<f32>[I, J] utens_stage,
     // Set up communication streams
     // The only PE-PE communication is for wcon, which is sent to the west  
     // We additionally set up a stream for the inputs and outputs
-    dataflow i, j in [0:I, 0:J] {
+    dataflow i16 i, i16 j in [0:I, 0:J] {
       stream<f32> u_stage_c = u_stage[i, j];
       stream<f32> wcon_c = wcon[i, j];
       stream<f32> u_pos_c = u_pos[i, j];
@@ -44,7 +44,7 @@ kernel vadv<I,J,K>(stream<f32>[I, J] utens_stage,
     
     // Copy the data
     
-    compute i, j in [0:I, 0:J] {
+    compute i16 i, i16 j in [0:I, 0:J] {
         foreach k, x in [0:K, receive(u_stage_c)] {
             u_stage_l[k] = x;
         }
@@ -69,7 +69,7 @@ kernel vadv<I,J,K>(stream<f32>[I, J] utens_stage,
 
   phase {
   
-    place i, j in [0:I, 0:J] {
+    place i16 i, i16 j in [0:I, 0:J] {
       # Local fields live inside the phases scope
       f32[K] gav;
       f32[K] gcv;
@@ -89,7 +89,7 @@ kernel vadv<I,J,K>(stream<f32>[I, J] utens_stage,
     // Set up communication streams
     // The only PE-PE communication is for wcon, which is sent to the west  
     // We additionally set up a stream for the outputs
-    dataflow i, j in [0:I, 0:J] {
+    dataflow i16 i, i16 j in [0:I, 0:J] {
       stream<f32> westwards = relative_stream(-1, 0);
       
       stream<f32> utens_stage_c = utens_stage[i, j];
@@ -99,7 +99,7 @@ kernel vadv<I,J,K>(stream<f32>[I, J] utens_stage,
     ////
     // Computation
   
-    compute i, j in [0, 0:J] {
+    compute i16 i, i16 j in [0, 0:J] {
       // Boundary condition
       // ...
       foreach k, x in [0:K, receive(westwards)] {
@@ -107,7 +107,7 @@ kernel vadv<I,J,K>(stream<f32>[I, J] utens_stage,
       }
     }
   
-    compute i, j in [1:I, 0:J] {
+    compute i16 i, i16 j in [1:I, 0:J] {
         
         send(wcon_local[0:1], westwards);
         send(wcon_local[1:K], westwards);
@@ -172,11 +172,11 @@ kernel laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
   
 
   
-  place i, j in [0:I+2, 0:J+2] {
+  place i16 i, i16 j in [0:I+2, 0:J+2] {
       f32[K] local_input;
   }
   
-  place i, j in [1:I+1, 1:J+1] {
+  place i16 i, i16 j in [1:I+1, 1:J+1] {
       f32[K] local_result;
   }
   
@@ -184,11 +184,11 @@ kernel laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
   
   phase {
   
-    dataflow i, j in [0:I+2, 0:J+2] {
+    dataflow i16 i, i16 j in [0:I+2, 0:J+2] {
       stream<f32> in_field_l = in_field[i, j];
     }
   
-    compute i, j in [0:I+2, 0:J+2] {
+    compute i16 i, i16 j in [0:I+2, 0:J+2] {
       foreach k, x in [0:K, receive(in_field_l)] {
         local_input[k] = x;
       }
@@ -198,7 +198,7 @@ kernel laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
 
   phase {
     // Set up communication streams
-    dataflow i, j in [0:I+2, 0:J+2] {
+    dataflow i16 i, i16 j in [0:I+2, 0:J+2] {
        stream<f32> eastwards = relative_stream(+1, 0);
        stream<f32> westwards = relative_stream(-1, 0);
        stream<f32> northwards = relative_stream(0, -1);
@@ -206,25 +206,25 @@ kernel laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
        
     }
 
-    dataflow i, i in [1:I+1, 1:J+1] {
+    dataflow i16 i, i16 j in [1:I+1, 1:J+1] {
         stream<f32> lap_field_l = lap_field[i, j];
     }
   
     // Edge senders
-    compute i, j in [0, 1:J] {
+    compute i16 i, i16 j in [0, 1:J] {
         // Streaming send to the right
         send(local_input, eastwards);
         // We receive nothing
     }
     
-    compute i, j in [I+1, 1:J] {
+    compute i16 i, i16 j in [I+1, 1:J] {
         // Streaming send to the left
         send(tosend, westwards);
         // We receive nothing
     }
     // ...
   
-    compute i, j in [1:I+1, 1:J+1] {
+    compute i16 i, i16 j in [1:I+1, 1:J+1] {
         // Streaming parallel computation (map)
         completion f = map i32 k in [0:K] {
             local_result[k] = local_input[k] * 4;
@@ -282,7 +282,7 @@ kernel <I, J, K>hdiff(stream<f32>[I, J] readonly in_stream,
                       stream<f32>[I, J] readonly coeff_stream) {
 
     // Data placement
-    place i, j in [0:I, 0:J] {
+    place i16 i, i16 j in [0:I, 0:J] {
         f32[K] in_field;
         // in field of the east neighbor
         f32[K] in_field_east;
@@ -298,12 +298,12 @@ kernel <I, J, K>hdiff(stream<f32>[I, J] readonly in_stream,
     
     // Read input
     phase {
-        dataflow i, j in [0:I, 0:J] {
+        dataflow i16 i, i16 j in [0:I, 0:J] {
             stream<f32> in_field_l = in_field[i, j];
             stream<f32> coeff_l = coeff[i, j];
         }
         
-        compute i, j in [0:I, 0:J] {
+        compute i16 i, i16 j in [0:I, 0:J] {
             foreach k, x in [0:K, receive(in_field_l)] {
                 in_field[k] = x;
             }
@@ -319,7 +319,7 @@ kernel <I, J, K>hdiff(stream<f32>[I, J] readonly in_stream,
     phase {
     
         // Set up communication streams
-        dataflow i, j in [0:I+2, 0:J+2] {
+        dataflow i16 i, i16 j in [0:I+2, 0:J+2] {
             stream<f32> eastwards = relative_stream(1, 0);
             stream<f32> westwards = relative_stream(-1, 0);
             stream<f32> northwards = relative_stream(0, -1);
@@ -342,7 +342,7 @@ kernel <I, J, K>hdiff(stream<f32>[I, J] readonly in_stream,
             in_field_east[k] = x;
         }
         // Then, decrement the lap_field using the stored in_field_east
-        await map k in [0:K] {
+        await map i32 k in [0:K] {
             lap_field[k] = lap_field[k] - in_field_east[k];
         }
         
@@ -364,7 +364,7 @@ kernel <I, J, K>hdiff(stream<f32>[I, J] readonly in_stream,
         // Note that we could re-use the same streams as in the previous phase
         // And we could also merge the two phases into one
     
-        dataflow i, j in [0:I, 0:J] {
+        dataflow i16 i, i16 j in [0:I, 0:J] {
             // Note that the directions are reversed compared to gt4py because
             // we specify the offsets to send to, wheres it specifies the offsets to read from
             stream<f32> west = relative_stream(-1, 0);
@@ -373,36 +373,36 @@ kernel <I, J, K>hdiff(stream<f32>[I, J] readonly in_stream,
             stream<f32> fly_field_stream = relative_stream(0, 1);
         }
         
-        compute i, j in [1:I-1, 1:J-1] {
+        compute i16 i, i16 j in [1:I-1, 1:J-1] {
             
             completion c = send(lap_field, west);
             
-            foreach k, x in [0:K, receive(west)] {
+            foreach i32 k, f32 x in [0:K, receive(west)] {
                 res[k] = x - lap_field[k];
             }
             
             await c;
             
-            await map k in [0:K] {
+            await map i32 k in [0:K] {
                 flx_field[k] = (res[k] * (in_field_east[k] - in_field[k])) <= 0) * res[k];
             }
             
             completion c3 = send(lap_field, north);
             
-            foreach k, y in [0:K, receive(north)] {
+            foreach i32 k, f32 y in [0:K, receive(north)] {
                 res[k] = y - lap_field[k];
             }
             
             await c3;
             
-            await map k in [0:K] {
+            await map i32 k in [0:K] {
                 fly_field[k] = (res[k] * (in_field_south[k] - in_field[k])) <= 0) * res[k];
             }
             
             completion c4 = send(flx_field, flx_field_stream);
 
             // No need to copy the flx_field, can accumulate directly
-            await foreach k, x in [0:K, receive(flx_field_stream)] {
+            await foreach i32 k, f32 x in [0:K, receive(flx_field_stream)] {
                 out_field[k] = flx_field[k] - x;
             }
             
@@ -411,11 +411,11 @@ kernel <I, J, K>hdiff(stream<f32>[I, J] readonly in_stream,
             completion c5 = send(fly_field, fly_field_stream);
             
             // No need to copy the fly_field, can accumulate directly
-            await foreach k, y in [0:K, receive(fly_field_stream)] {
+            await foreach i32 k, f32 y in [0:K, receive(fly_field_stream)] {
                 out_field[k] = outfield[k] + fly_field[k] - y;
             }
             
-            await map k in [0:K] {
+            await map i32 k in [0:K] {
                 out_field[k] = in_field[k] - local_coeff[k] * out_field[k];
             }
             
@@ -425,22 +425,22 @@ kernel <I, J, K>hdiff(stream<f32>[I, J] readonly in_stream,
             send(out_field, out_stream);
         }
         
-        compute i, j in [0, 1:J-1] {
+        compute i16 i, i16 j in [0, 1:J-1] {
             // Boundary condition
             // ...
         }
         
-        compute i, j in [I, 1:J-1] {
+        compute i16 i, i16 j in [I, 1:J-1] {
             // Boundary condition
             // ...
         }
         
-        compute i, j in [1:I-1, 0] {
+        compute i16 i, i16 j in [1:I-1, 0] {
             // Boundary condition
             // ...
         }
         
-        compute i, j in [1:I-1, J] {
+        compute i16 i, i16 j in [1:I-1, J] {
             // Boundary condition
             // ...
         }
@@ -461,35 +461,32 @@ While the data is being streamed, it is convolved with the kernel and streamed t
 ```rust
 kernel conv<J>(stream<f32>[J] readonly input,
                stream<f32>[J] writeonly output,
-               f32[3] readonly KERNEL) {
+               f32[3] readonly kernel) {
 
     // Data placement
-    place i, 0 in [0:J, 0] {
+    place i16 i, i16 j in [0:J, 0] {
         f32 y;
-        f32[3] kernel <- KERNEL;
     }
 
     // Communication
     dataflow i, j in [0:J, 0] {
         stream<f32> eastwards = relative_stream(1, 0);
         stream<f32> westwards = relative_stream(-1, 0);
-        stream<f32> input_local <- input[i];
-        stream<f32> output_local -> output[i];
     }
 
     // Computation
-    compute i, j in [1:J-1, 0] {
+    compute i16 i, i16 j in [1:J-1, 0] {
 
         // Streaming receive
         // Each PE receives a single scalar per time step
-        foreach x in receive(input_local) {
+        foreach f32 x in receive(input[i]) {
 
             y = x * kernel[1];
 
             // Send the data to the right
             comp_east = send(x, eastwards);
 
-            await foreach k, x2 in [0:1, receive(eastwards)] {
+            await foreach i16 k, f32 x2 in [0:1, receive(eastwards)] {
               y = y + x2 * kernel[0];
             }
 
@@ -498,28 +495,28 @@ kernel conv<J>(stream<f32>[J] readonly input,
             // Send the data to the left
             comp_west = send(x, westwards);
 
-            await foreach k, x3 in [0:1, receive(westwards)] {
+            await foreach i16 k, f32 x3 in [0:1, receive(westwards)] {
                y = y + x3 * kernel[2];
             }
 
             await comp_west;
 
             // Send the result to the output
-            await send(y, output_local);
+            await send(y, output[i]);
         }
     }
 
     // Left corner
-    compute i, 0 in [0, 0] {
+    compute i16 i, i16 j in [0, 0] {
         // Streaming receive
-        foreach x in receive(input_local) {
+        foreach f32 x in receive(input[i]) {
             // Send the data to the right
             // S1
             comp_east = send(x, eastwards);
             // S2
             y = x * kernel[1];
             // S3
-            await foreach x, y in [0:1, receive(westwards)] {
+            await foreach i16 x, f32 y in [0:1, receive(westwards)] {
                 // S4
                 y = y + x * kernel[2];
             }

--- a/irspec/docs/spatial/routing.md
+++ b/irspec/docs/spatial/routing.md
@@ -87,7 +87,7 @@ and record the stream $F$, channel $C$, and corresponding stream edge.
     are properly sequenced in different phases.
     ```rust
     // 1D 2-phase reduce for 4 PEs
-    place i, j in [0:4, 0] {
+    place i16 i, i16 j in [0:4, 0] {
         f32[K] a;
     }
     

--- a/irspec/docs/spatial/routing.md
+++ b/irspec/docs/spatial/routing.md
@@ -102,7 +102,7 @@ and record the stream $F$, channel $C$, and corresponding stream edge.
         send(a, hop1);
       }
       compute i32 i, i32 j in [0:4:2] {
-        foreach i32 k, i32 x in [0:K, receive(hop1)] {
+        foreach i32 k, i32 x in [0:K], receive(hop1) {
           a[k] += x
         }
       }
@@ -121,7 +121,7 @@ and record the stream $F$, channel $C$, and corresponding stream edge.
       }
     
       compute i32 i, i32 j in [0, 0] {
-        foreach i32 k, i32 x in [0:K, receive(hop2)] {
+        foreach i32 k, i32 x in [0:K], receive(hop2) {
           a[k] += x
         }
       }

--- a/irspec/docs/spatial/spatial.md
+++ b/irspec/docs/spatial/spatial.md
@@ -358,12 +358,12 @@ asynchronous and return completions that may be used to synchronize computations
 completion completion_name = send(local_array, stream_name);
 
 // Foreach loop over a receive() stream until the sender is done (asynchronous)
-completion completion_name = foreach variables in [receive(stream_name)] {
+completion completion_name = foreach variables in receive(stream_name) {
   // Statements
 }
 
 // Foreach loop over a receive() stream of defined size (asynchronous)
-completion completion_name = foreach variables in [parameter_expressions, receive(stream_name)] {
+completion completion_name = foreach variables in [parameter_expressions], receive(stream_name) {
   // Statements
 }
 // Parallel map (asynchronous)
@@ -426,7 +426,7 @@ await c;
     // Wait for completion of a send
     await send(local_array, stream_name);
     // Wait for completion of a receive
-    await foreach i32 k, f32 x in [0:K, receive(stream_name)] {
+    await foreach i32 k, f32 x in [0:K], receive(stream_name) {
       // Statements
     }
     // Wait for a completion
@@ -522,12 +522,12 @@ The elements are processed in the order they are received.
 One may either provide the number of elements to receive, or receive until the sender is done.
 ```rust
 // Receive until the sender is done
-completion completion_name = foreach variables in [receive(stream_name)] {
+completion completion_name = foreach variables in receive(stream_name) {
   // Assignment statements
 }
 
 // Receive a fixed number of elements
-completion completion_name = foreach variables in [parameter_range_expressions, receive(stream_name)] {
+completion completion_name = foreach variables in [parameter_range_expressions], receive(stream_name) {
   // Assignment statements
 }
 ```
@@ -544,7 +544,7 @@ to allow for performance optimizations.
 For example, the following code receives data from `stream_1` for `K` elements
 and assigns the received data to the array `a`.
 ```
-completion completion_name = foreach i32 k, f32 x in [0:K, receive(stream_1)] {
+completion completion_name = foreach i32 k, f32 x in [0:K], receive(stream_1) {
     a[k] = x;
 }
 ```

--- a/irspec/docs/spatial/spatial.md
+++ b/irspec/docs/spatial/spatial.md
@@ -391,7 +391,59 @@ array_expression = expression;
 field_name = expression;
 ```
 
-Note that each completion name must be unique within a `compute` block.
+### Asynchronous Execution with Completions
+
+A completion is a built-in identifier type that can be used to control asynchronous execution.
+
+In a well-formed code, every asynchronous element must either have a `completion` definition assigned, or be prefixed
+with `await`. This includes asynchronous blocks (`foreach`, `map`, `async`) and asynchronous built-in functions (`send`,
+`receive`) that appear in the top-level `compute` scope.
+
+A `completion` object cannot be defined on its own (i.e., `completion c`), nor can it be reassigned. Each completion
+name must be unique within a `compute` block.
+
+### Await completions with `await`
+
+Inside a `compute` block, an `await` statement is used to wait for a completion to trigger.
+The `await` can be applied to a completion name.
+```rust
+await completion_name;
+```
+The `await` can be immediately applied to an asynchronous operation as a shorthand:
+```
+await operation;
+// Is semantically equivalent to:
+completion c = operation;
+await c;
+```
+
+??? example "Example: await"
+    ```rust
+    // Execute a map and wait for its completion
+    await map i32 i in [0:10] {
+        // Statements
+    }
+    // Wait for completion of a send
+    await send(local_array, stream_name);
+    // Wait for completion of a receive
+    await foreach i32 k, f32 x in [0:K, receive(stream_name)] {
+      // Statements
+    }
+    // Wait for a completion
+    await comp;
+    ```
+
+!!! note 
+    Note that statements inside an `await` may still be preempted by other asynchronous operations!
+    
+!!! danger "Undefined Behavior"
+    Awaiting the same completion twice is considered undefined behavior.
+    
+
+Any completion that is never `await`ed is assumed to have an implicit `await` at the end of its parent `compute` block.
+
+See the [Semantics of Asynchronous Statements](../async#semantics-of-asynchronous-statements) for more details
+on the semantics of `await`.
 
 ### Streaming Data with `send`
 
@@ -544,46 +596,6 @@ Hence, the map must not contain loop-carried dependencies.
 !!! note
     If you need to perform non-affine array accesses, exploit loop-carried dependencies, 
     or nest other asynchronous operations, use a [`for`](#processing-arrays-sequentially-with-for) loop instead.
-
-### Await completions with `await`
-
-Inside a `compute` block, an `await` statement is used to wait for a completion to trigger.
-The `await` can be applied to a completion name.
-```rust
-await completion_name;
-```
-The `await` can be immediately applied to an asynchronous operation as a shorthand:
-```
-await operation;
-// Is semantically equivalent to:
-completion c = operation;
-await c;
-```
-
-??? example "Example: await"
-    ```rust
-    // Execute a map and wait for its completion
-    await map i32 i in [0:10] {
-        // Statements
-    }
-    // Wait for completion of a send
-    await send(local_array, stream_name);
-    // Wait for completion of a receive
-    await foreach i32 k, f32 x in [0:K, receive(stream_name)] {
-      // Statements
-    }
-    // Wait for a completion
-    await comp;
-    ```
-
-!!! note 
-    Note that statements inside an `await` may still be preempted by other asynchronous operations!
-    
-!!! danger "Undefined Behavior"
-    Awaiting the same completion twice is considered undefined behavior.
-    
-See the [Semantics of Asynchronous Statements](../async#semantics-of-asynchronous-statements) for more details
-on the semantics of `await`.
 
 ### Processing arrays sequentially with `for`
 

--- a/irspec/docs/spatial/spatial.md
+++ b/irspec/docs/spatial/spatial.md
@@ -519,7 +519,12 @@ Inside a `compute` block, a `foreach` loop can be used to apply a computation to
 For each element in the stream, the computation is executed.
 The elements are processed in the order they are received.
 
-One may either provide the number of elements to receive, or receive until the sender is done.
+The foreach loop is defined on a generator (i.e., `receive(stream_name)`), and may optionally
+accept an additional range iterator (for example, `[0:K]` or `[0:2, 0:N]`). If an additional
+range iterator is provided, it is considered as an implicit zip operator, in which the range
+will terminate the loop upon completion. This range can be used to provide a fixed number of
+elements to receive. Otherwise, the `foreach` loop will receive until the sender is done:
+
 ```rust
 // Receive until the sender is done
 completion completion_name = foreach variables in receive(stream_name) {
@@ -531,10 +536,13 @@ completion completion_name = foreach variables in [parameter_range_expressions],
   // Assignment statements
 }
 ```
-The last variable is the data variable. The data variable is bound to the received data. Its type must match the type of the stream.
+The variable at the corresponding position to the `receive` generator is bound to the received data.
+Its type must match the type of the stream. The other variables are iteration variables.
 
-The other variables are iteration variables. They must be of type `i32`.
-One may specify multiple parameter range expressions. 
+The order of range iterators and `receive` generator does not matter. A program in its canonical form will place
+the `receive` generator last.
+
+For the iteration variables, one may specify multiple parameter range expressions. 
 The iteration variables are bound to the indices of the received data, which is
 interpreted as a multi-dimensional array in *row-major* order.
 

--- a/irspec/docs/spatial/spatial.md
+++ b/irspec/docs/spatial/spatial.md
@@ -475,7 +475,7 @@ completion completion_name = foreach variables in [receive(stream_name)] {
 }
 
 // Receive a fixed number of elements
-completion completion_name = foreach variables in [parameter_rage_expressions, receive(stream_name)] {
+completion completion_name = foreach variables in [parameter_range_expressions, receive(stream_name)] {
   // Assignment statements
 }
 ```

--- a/irspec/docs/spatial/spatial.md
+++ b/irspec/docs/spatial/spatial.md
@@ -248,7 +248,7 @@ a stream for receiving from the PE at the relative position `(i-dx, j-dy)` at th
 ??? example "Example: Relative Stream Declaration"
     For example,
     ```rust
-    dataflow i, j in [0:I, 0:J] {
+    dataflow i16 i, i16 j in [0:I, 0:J] {
         stream<f32> eastwards = relative_stream(1, 0);
         stream<f32> westwards = relative_stream(-1, 0);
         stream<f32> northwards = relative_stream(0, -1);
@@ -259,7 +259,7 @@ a stream for receiving from the PE at the relative position `(i-dx, j-dy)` at th
 
     For example,
     ```rust
-    dataflow i, j in [0:I, 0:J] {
+    dataflow i16 i, i16 j in [0:I, 0:J] {
         stream<i32> two_north = relative_stream(0, -2);
     }
     ```
@@ -300,7 +300,7 @@ Note that the start and end PEs also count as hops implicitly.
 
 ???+ example "Example: Routing Declaration"
     ```rust
-    dataflow i, j in [0:I, 0:J] {
+    dataflow i16 i, i16 j in [0:I, 0:J] {
         stream<f32> eastwards = relative_stream(1, 0) {
             hops = [(1, 0)];
             channel = 0;
@@ -315,7 +315,7 @@ One may also provide `hops` explicitly, but leave `channel = auto`, which allows
 ```rust
 // Example use of channel=auto
 
-dataflow i, j in [0:I, 0:J] {
+dataflow i16 i, i16 j in [0:I, 0:J] {
     stream<f32> eastwards = relative_stream(1, 0) {
         hops = auto;
         channel = auto;
@@ -355,7 +355,7 @@ that lie in the `subgrid_expression`.
 asynchronous and return completions that may be used to synchronize computations.
 ```rust
 // Send (asynchronous)
-completion_name = send(local_array, stream_name);
+completion completion_name = send(local_array, stream_name);
 
 // Foreach loop over a receive() stream until the sender is done (asynchronous)
 completion completion_name = foreach variables in [receive(stream_name)] {
@@ -665,24 +665,24 @@ A PEs may participate in some phases and not in others.
 
 ??? example "Example: Phases"
     ```rust
-    place for i, j in [0:I, 0:J] {
+    place i16 i, i16 j in [0:I, 0:J] {
         f32[K] a;
     }
     
-    dataflow for i, j in [0:I, 0:J] {
+    dataflow i16 i, i16 j in [0:I, 0:J] {
       stream<f32> input = arg1[i, j, 0:K];
     }
     
     phase {
-      place for i, j in [0:I, 0:J] {
+      place i16 i, i16 j in [0:I, 0:J] {
         f32[K] b;
       }
        
-      dataflow for i, j in [0:I, 0:J] {
+      dataflow i16 i, i16 j in [0:I, 0:J] {
         stream<f32> eastwards = relative_stream(1, 0);
       }
       
-      compute for i, j in [0:I, 0:J] {
+      compute i16 i, i16 j in [0:I, 0:J] {
          // Within this compute block:
          // b and a are in scope, eastwards is in scope, input are in scope
       }
@@ -691,17 +691,17 @@ A PEs may participate in some phases and not in others.
     
     phase {
     
-      place for i, j in [1:I-1, 1:J-1] {
+      place i16 i, i16 j in [1:I-1, 1:J-1] {
         f32[K] c;
         stream<f32> output = arg2[i, j];
       }
     
-      dataflow for i, j in [1:I-1, 1:J-1] {
+      dataflow i16 i, i16 j in [1:I-1, 1:J-1] {
         // The communication pattern switches direction in this phase
         stream<f32> westwards = relative_stream(-1, 0);
       }
       
-      compute for i, j in [1:I-1, 1:J-1] {
+      compute i16 i, i16 j in [1:I-1, 1:J-1] {
         // Within this compute block:
         // c is in scope, westwards, input and output are in scope
       }

--- a/irspec/docs/stencil/lowering.md
+++ b/irspec/docs/stencil/lowering.md
@@ -205,14 +205,14 @@ Otherwise, the computation is performed locally on the PE using a map.
 
     // Send, receive, for %in[-1, 0, 0]
     completion c1 = send(in, in_stream_0);
-    await foreach k, x in [0:K, receive(in_stream_0)] {
+    await foreach k, x in [0:K], receive(in_stream_0) {
         out_1[k] = out_1[k] - x;
     }
     await c1;
 
     // Send, receive, for %in[1, 0, 0]
     completion c2 = send(in, in_stream_1);
-    await foreach k, x in [0:K, receive(in_stream_1)] {
+    await foreach k, x in [0:K], receive(in_stream_1) {
         out_1[k] = out_1[k] + x;
     }
     await c2;

--- a/samples/spatial/laplacian.sptl
+++ b/samples/spatial/laplacian.sptl
@@ -1,0 +1,88 @@
+kernel laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
+                         stream<f32>[I, J] writeonly lap_field) {
+    
+  ////////////////////////////////
+  // Data placement
+  place i, j in [0:I+2, 0:J+2] {
+      f32[K] local_input;
+  }
+  
+  place i, j in [1:I+1, 1:J+1] {
+      f32[K] local_result;
+  }
+  
+  // Copy input data
+  phase {
+  
+    dataflow i, j in [0:I+2, 0:J+2] {
+      stream<f32> in_field_l = in_field[i, j];
+    }
+  
+    compute i, j in [0:I+2, 0:J+2] {
+      foreach k, x in [0:K, receive(in_field_l)] {
+        local_input[k] = x;
+      }
+    }
+  }
+  
+
+  phase {
+    // Set up communication streams
+    dataflow i, j in [0:I+2, 0:J+2] {
+       stream<f32> eastwards = relative_stream(+1, 0);
+       stream<f32> westwards = relative_stream(-1, 0);
+       stream<f32> northwards = relative_stream(0, -1);
+       stream<f32> southwards = relative_stream(0, +1);
+       
+    }
+
+    dataflow i, i in [1:I+1, 1:J+1] {
+        stream<f32> lap_field_l = lap_field[i, j];
+    }
+  
+    // Edge senders
+    compute i, j in [0, 1:J] {
+        // Streaming send to the right
+        send(local_input, eastwards);
+        // We receive nothing
+    }
+    
+    compute i, j in [I+1, 1:J] {
+        // Streaming send to the left
+        send(tosend, westwards);
+        // We receive nothing
+    }
+    // ...
+  
+    compute i, j in [1:I+1, 1:J+1] {
+        // Streaming parallel computation (map)
+        completion f = map i32 k in [0:K] {
+            local_result[k] = local_input[k] * 4;
+        }
+  
+        // No data race, both map and send are reading from local_input
+        send(local_input, westwards);
+
+        // Example of an await for a completion.
+        await f;
+        
+        // Writing to local_result form the map would be considered a data race
+        // if we did not await f
+        await foreach i32 k, f32 x in [0:K, receive(westwards)] {
+          local_result[k] = local_result[k] - x;
+        }
+
+        // Writing to the same array from multiple foreach blocks concurrently
+        // is considered a data race.
+        // Hence, we need to run one after the other.
+        send(local_input, eastwards);
+        await foreach i32 k, f32 x in [0:K, receive(eastwards)] {
+          local_result[k] = local_result[k] - x;
+        }
+        // ...
+
+        // after all computation has finished:
+        await send(local_result, lap_field_l);   
+    }  
+  }
+}

--- a/samples/spatial/laplacian.sptl
+++ b/samples/spatial/laplacian.sptl
@@ -14,6 +14,7 @@ kernel @laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
   // Copy input data
   phase {
     compute i16 i, i16 j in [0:I+2, 0:J+2] {
+      await receive(local_input, in_field[i, j])
     }
   }
   
@@ -29,13 +30,13 @@ kernel @laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
     // Edge senders
     compute i16 i, i16 j in [0:1, 1:J] {
         // Streaming send to the right
-        send(local_input, eastwards);
+        await send(local_input, eastwards);
         // We receive nothing
     }
     
     compute i16 i, i16 j in [I+1:I+2, 1:J] {
         // Streaming send to the left
-        send(tosend, westwards);
+        await send(tosend, westwards);
         // We receive nothing
     }
     // ...
@@ -47,7 +48,7 @@ kernel @laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
         }
   
         // No data race, both map and send are reading from local_input
-        send(local_input, westwards);
+        await send(local_input, westwards);
 
         // Example of an await for a completion.
         await f;
@@ -61,14 +62,15 @@ kernel @laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
         // Writing to the same array from multiple foreach blocks concurrently
         // is considered a data race.
         // Hence, we need to run one after the other.
-        send(local_input, eastwards);
+        await send(local_input, eastwards)
+
         await foreach i32 k, f32 x in receive(eastwards), [0:K] {
           local_result[k] = local_result[k] - x;
         }
         // ...
 
         // after all computation has finished:
-        /*await*/ send(local_result, lap_field[i, j])
+        await send(local_result, lap_field[i, j])
     }  
   }
 }

--- a/samples/spatial/laplacian.sptl
+++ b/samples/spatial/laplacian.sptl
@@ -1,5 +1,5 @@
-kernel laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
-                         stream<f32>[I, J] writeonly lap_field) {
+kernel @laplacian<I,J,K> (f32[K] readonly in_field,
+                          f32[K] writeonly lap_field) {
     
   ////////////////////////////////
   // Data placement
@@ -13,14 +13,15 @@ kernel laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
   
   // Copy input data
   phase {
-  
+    /*
     dataflow i, j in [0:I+2, 0:J+2] {
       stream<f32> in_field_l = in_field[i, j];
     }
+    */
   
     compute i, j in [0:I+2, 0:J+2] {
-      foreach k, x in [0:K, receive(in_field_l)] {
-        local_input[k] = x;
+      map i32 k in [0:K] {
+        local_input[k] = in_field[k];
       }
     }
   }
@@ -36,18 +37,20 @@ kernel laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
        
     }
 
+    /*
     dataflow i, i in [1:I+1, 1:J+1] {
         stream<f32> lap_field_l = lap_field[i, j];
     }
+    */
   
     // Edge senders
-    compute i, j in [0, 1:J] {
+    compute i, j in [0:1, 1:J] {
         // Streaming send to the right
         send(local_input, eastwards);
         // We receive nothing
     }
     
-    compute i, j in [I+1, 1:J] {
+    compute i, j in [I+1:I+2, 1:J] {
         // Streaming send to the left
         send(tosend, westwards);
         // We receive nothing
@@ -82,7 +85,9 @@ kernel laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
         // ...
 
         // after all computation has finished:
-        await send(local_result, lap_field_l);   
+        await map i32 k in [0:K] {
+          out_field[k] = local_result[k];
+        }   
     }  
   }
 }

--- a/samples/spatial/laplacian.sptl
+++ b/samples/spatial/laplacian.sptl
@@ -3,24 +3,23 @@ kernel @laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
     
   ////////////////////////////////
   // Data placement
-  place i, j in [0:I+2, 0:J+2] {
+  place i16 i, i16 j in [0:I+2, 0:J+2] {
       f32[K] local_input;
   }
   
-  place i, j in [1:I+1, 1:J+1] {
+  place i16 i, i16 j in [1:I+1, 1:J+1] {
       f32[K] local_result;
   }
   
   // Copy input data
   phase {
-    compute i, j in [0:I+2, 0:J+2] {
-      receive(local_input, in_field[i, j])
+    compute i16 i, i16 j in [0:I+2, 0:J+2] {
     }
   }
   
   phase {
     // Set up communication streams
-    dataflow i, j in [0:I+2, 0:J+2] {
+    dataflow i16 i, i16 j in [0:I+2, 0:J+2] {
        stream<f32> eastwards = relative_stream(+1, 0);
        stream<f32> westwards = relative_stream(-1, 0);
        stream<f32> northwards = relative_stream(0, -1);
@@ -28,20 +27,20 @@ kernel @laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
     }
 
     // Edge senders
-    compute i, j in [0:1, 1:J] {
+    compute i16 i, i16 j in [0:1, 1:J] {
         // Streaming send to the right
         send(local_input, eastwards);
         // We receive nothing
     }
     
-    compute i, j in [I+1:I+2, 1:J] {
+    compute i16 i, i16 j in [I+1:I+2, 1:J] {
         // Streaming send to the left
         send(tosend, westwards);
         // We receive nothing
     }
     // ...
   
-    compute i, j in [1:I+1, 1:J+1] {
+    compute i16 i, i16 j in [1:I+1, 1:J+1] {
         // Streaming parallel computation (map)
         completion f = map i32 k in [0:K] {
             local_result[k] = local_input[k] * 4;
@@ -63,7 +62,7 @@ kernel @laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
         // is considered a data race.
         // Hence, we need to run one after the other.
         send(local_input, eastwards);
-        await foreach i32 k, f32 x in [0:K, receive(eastwards)] {
+        await foreach i32 k, f32 x in receive(eastwards), [0:K] {
           local_result[k] = local_result[k] - x;
         }
         // ...

--- a/samples/spatial/laplacian.sptl
+++ b/samples/spatial/laplacian.sptl
@@ -1,5 +1,5 @@
-kernel @laplacian<I,J,K> (f32[K] readonly in_field,
-                          f32[K] writeonly lap_field) {
+kernel @laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
+                          stream<f32>[I, J] writeonly lap_field) {
     
   ////////////////////////////////
   // Data placement
@@ -13,20 +13,11 @@ kernel @laplacian<I,J,K> (f32[K] readonly in_field,
   
   // Copy input data
   phase {
-    /*
-    dataflow i, j in [0:I+2, 0:J+2] {
-      stream<f32> in_field_l = in_field[i, j];
-    }
-    */
-  
     compute i, j in [0:I+2, 0:J+2] {
-      map i32 k in [0:K] {
-        local_input[k] = in_field[k];
-      }
+      receive(local_input, in_field[i, j])
     }
   }
   
-
   phase {
     // Set up communication streams
     dataflow i, j in [0:I+2, 0:J+2] {
@@ -34,15 +25,8 @@ kernel @laplacian<I,J,K> (f32[K] readonly in_field,
        stream<f32> westwards = relative_stream(-1, 0);
        stream<f32> northwards = relative_stream(0, -1);
        stream<f32> southwards = relative_stream(0, +1);
-       
     }
 
-    /*
-    dataflow i, i in [1:I+1, 1:J+1] {
-        stream<f32> lap_field_l = lap_field[i, j];
-    }
-    */
-  
     // Edge senders
     compute i, j in [0:1, 1:J] {
         // Streaming send to the right
@@ -85,9 +69,7 @@ kernel @laplacian<I,J,K> (f32[K] readonly in_field,
         // ...
 
         // after all computation has finished:
-        await map i32 k in [0:K] {
-          out_field[k] = local_result[k];
-        }   
+        /*await*/ send(local_result, lap_field[i, j])
     }  
   }
 }

--- a/samples/spatial/laplacian.sptl
+++ b/samples/spatial/laplacian.sptl
@@ -55,7 +55,7 @@ kernel @laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
         
         // Writing to local_result form the map would be considered a data race
         // if we did not await f
-        await foreach i32 k, f32 x in [0:K, receive(westwards)] {
+        await foreach i32 k, f32 x in [0:K], receive(westwards) {
           local_result[k] = local_result[k] - x;
         }
 
@@ -64,8 +64,7 @@ kernel @laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
         // Hence, we need to run one after the other.
         await send(local_input, eastwards)
 
-        //TODO: await foreach f32 x, i32 k in receive(eastwards), [0:K] {
-        await foreach i32 k, f32 x in [0:K, receive(eastwards)] {
+        await foreach f32 x, i32 k in receive(eastwards), [0:K] {
           local_result[k] = local_result[k] - x;
         }
         // ...

--- a/samples/spatial/laplacian.sptl
+++ b/samples/spatial/laplacian.sptl
@@ -64,7 +64,8 @@ kernel @laplacian<I,J,K> (stream<f32>[I+2, J+2] readonly in_field,
         // Hence, we need to run one after the other.
         await send(local_input, eastwards)
 
-        await foreach i32 k, f32 x in receive(eastwards), [0:K] {
+        //TODO: await foreach f32 x, i32 k in receive(eastwards), [0:K] {
+        await foreach i32 k, f32 x in [0:K, receive(eastwards)] {
           local_result[k] = local_result[k] - x;
         }
         // ...

--- a/spatialstencil/syntax/common/basenode.py
+++ b/spatialstencil/syntax/common/basenode.py
@@ -1,6 +1,7 @@
 """
 Provides a base class for AST/IR trees. Includes children queries and schema validation.
 """
+import inspect
 import types
 import typing
 import warnings
@@ -49,8 +50,12 @@ class BaseNode:
 
             for item in typing.get_args(sequence):
                 if isinstance(item, str):
-                    warnings.warn(f"Could not validate schema for field {f_name} of {cls} due to forward reference")
-                    continue
+                    module = inspect.getmodule(cls)
+                    if not hasattr(module, item):
+                        warnings.warn(f"Could not validate schema for field {f_name} of {cls} due to forward reference")
+                        continue
+                    item = getattr(module, item)  # Try to obtain class from the same module
+
                 if typing.get_origin(item) is types.UnionType or typing.get_origin(item) is typing.Union:
                     _check_union(item, field_name)
                 elif issubclass(item, BaseNode):

--- a/spatialstencil/syntax/common/visitor.py
+++ b/spatialstencil/syntax/common/visitor.py
@@ -63,12 +63,44 @@ class IRNodeVisitor(Generic[BaseNodeT]):
 
 
 class ScopedIRNodeVisitor(IRNodeVisitor[BaseNodeT]):
+    """
+    A scoped version of the IR node visitor that contains methods to locate the current scope,
+    add pre/post visitors for each scope, as well as a visitor for the contents of each scope.
+
+    Extending a scope visitor can be done by extending ``visit_<NODE TYPE>`` normally, but for
+    each scope node type, more methods are exposed for scope analysis: ``pre_visit_<NODE TYPE>``,
+    ``do_visit_<NODE TYPE>``, and ``post_visit_<NODE TYPE>``. For proper scope management,
+    only override ``do_visit_<NODE TYPE>`` for scope node types.
+    """
 
     _current_scope: list[BaseNodeT]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._current_scope = []
+
+    def _do_nothing(self, node):
+        pass
+
+    def _visit_ScopeNode(self, node: BaseNodeT):
+        """
+        A generic method that visits a scope of a specific type.
+        """
+        typestr = type(node).__name__
+
+        # Pre-visit, if exists
+        getattr(self, f'pre_visit_{typestr}', self._do_nothing)(node)
+        # Setup scope
+        self.push_scope(node)
+        # Visit scope contents
+        result = getattr(self, f'do_visit_{typestr}', self.generic_visit)(node)
+        # Pop scope
+        self.pop_scope()
+        # Post-visit, if exists
+        getattr(self, f'post_visit_{typestr}', self._do_nothing)(node)
+
+        # Return result from visiting scope contents
+        return result
 
     def get_scope(self) -> BaseNodeT:
         return self._current_scope[-1]

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -101,13 +101,10 @@ class TypedIdentifier(SpatialNode):
     A variable identifier (e.g., x, y, my_variable) with a type.
     """
     dtype: Union[ScalarType, StreamType, ArrayType]
-    name: str
-    version: int
+    identifier: Identifier
 
     def as_ir(self, indent: int = 0) -> str:
-        if self.version == 0:
-            return f'{self.dtype.as_ir()} {self.name}'
-        return f'{self.dtype.as_ir()} {self.name}#{self.version}'
+        return f'{self.dtype.as_ir()} {self.identifier.as_ir()}'
 
 
 # Unary Operators
@@ -426,7 +423,7 @@ class ForeachStatement(Statement):
     variables: list[TypedIdentifier]
     parameter_range: list[RangeExpression]
     stream_variable: Identifier
-    receive_stream: Identifier
+    receive_stream: ReceiveGenerator
     body: list[Statement]
     completion_name: Optional[Completion] = None
 
@@ -440,9 +437,9 @@ class ForeachStatement(Statement):
         body_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.body)
 
         if self.parameter_range:
-            main_str = f'foreach {vars_str} in [{rng_str}], receive({self.receive_stream.as_ir()}) {{\n{body_str}\n{indent_str}}}'
+            main_str = f'foreach {vars_str} in [{rng_str}], {self.receive_stream.as_ir()} {{\n{body_str}\n{indent_str}}}'
         else:
-            main_str = f'foreach {vars_str} in receive({self.receive_stream.as_ir()}) {{\n{body_str}\n{indent_str}}}'
+            main_str = f'foreach {vars_str} in {self.receive_stream.as_ir()} {{\n{body_str}\n{indent_str}}}'
 
         if self.completion_name:
             return f'{indent_str}{self.completion_name.as_ir()} = {main_str}'
@@ -536,25 +533,6 @@ class AssignmentStatement(Statement):
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
         return f'{indent_str}{self.destination.as_ir()} = {self.source.as_ir()}'
-
-
-@dataclass
-class DefinitionStatement(Statement):
-    """
-    Assigns the result of an expression to a field or variable
-    """
-    dtype: Union[ScalarType, StreamType]
-    destination: Identifier
-    source: Expression
-
-    def validate(self) -> None:
-        assert isinstance(self.source, Expression)
-        assert isinstance(self.destination, (ArraySlice, Identifier))
-        assert isinstance(self.dtype, (ScalarType, StreamType))
-
-    def as_ir(self, indent: int = 0) -> str:
-        indent_str = '  ' * indent
-        return f'{indent_str}{self.dtype.as_ir()} {self.destination.as_ir()} = {self.source.as_ir()}'
 
 
 # Compute Block

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -260,7 +260,7 @@ class PlaceBlock(SpatialNode):
     """
     The 'place' block for allocating variables or arrays on a subgrid of PEs.
     """
-    variables: list[Identifier]
+    variables: list[TypedIdentifier]
     subgrid: SubgridExpression
     statements: list[FieldDeclaration]
 
@@ -329,12 +329,12 @@ class DataflowBlock(SpatialNode):
     """
     The 'dataflow' block for describing communication streams between PEs.
     """
-    variables: list[Identifier]
+    variables: list[TypedIdentifier]
     subgrid: SubgridExpression
     statements: list[RelativeStreamDeclaration]
 
     def validate(self) -> None:
-        assert all(isinstance(var, Identifier) for var in self.variables)
+        assert all(isinstance(var, TypedIdentifier) for var in self.variables)
         assert all(isinstance(stmt, RelativeStreamDeclaration) for stmt in self.statements)
         assert len(self.variables) == 2
 
@@ -386,7 +386,7 @@ class SendStatement(Statement):
         indent_str = '  ' * indent
         if self.completion_name:
             return f'{indent_str}{self.completion_name.as_ir()} = send({self.local_array.as_ir()}, {self.stream_name.as_ir()})'
-        return f'{indent_str}send({self.local_array.as_ir()}, {self.stream_name.as_ir()})'
+        return f'{indent_str}await send({self.local_array.as_ir()}, {self.stream_name.as_ir()})'
 
 
 @dataclass
@@ -402,20 +402,19 @@ class ReceiveStatement(Statement):
         indent_str = '  ' * indent
         if self.completion_name:
             return f'{indent_str}{self.completion_name.as_ir()} = receive({self.local_array.as_ir()}, {self.stream_name.as_ir()})'
-        return f'{indent_str}receive({self.local_array.as_ir()}, {self.stream_name.as_ir()})'
+        return f'{indent_str}await receive({self.local_array.as_ir()}, {self.stream_name.as_ir()})'
 
 
-# Receive Statement
+# Receive generator
 @dataclass
-class Receive(SpatialNode):
+class ReceiveGenerator(SpatialNode):
     """
-    Receive data from a stream, used in a foreach statement.
+    Receive data from a stream, used as a generator in a foreach statement.
     """
     stream_name: Identifier
 
     def as_ir(self, indent: int = 0) -> str:
-        indent_str = '  ' * indent
-        return f'{indent_str}receive({self.stream_name.as_ir()})'
+        return f'receive({self.stream_name.as_ir()})'
 
 
 # Foreach Loop (asynchronous)
@@ -424,11 +423,14 @@ class ForeachStatement(Statement):
     """
     Foreach loop for asynchronously iterating over a received stream.
     """
-    variables: list[Identifier]
-    receive_stream: Receive
+    variables: list[TypedIdentifier]
+    parameter_range: list[RangeExpression]
+    receive_stream: Identifier
     body: list[Statement]
     completion_name: Optional[Completion] = None
-    parameter_range: Optional[list[RangeExpression]] = None
+
+    def validate(self) -> None:
+        assert len(self.variables) == len(self.parameter_range) + 1
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
@@ -453,7 +455,7 @@ class MapStatement(Statement):
     """
     Map statement for applying an affine computation asynchronously to array elements.
     """
-    variables: list[Identifier]
+    variables: list[TypedIdentifier]
     range_expression: list[RangeExpression]
     body: list[Statement]
     completion_name: Optional[Completion] = None
@@ -475,7 +477,7 @@ class ForStatement(Statement):
     """
     Sequential for loop for iterating over a range expression.
     """
-    variables: list[Identifier]
+    variables: list[TypedIdentifier]
     range_expression: list[RangeExpression]
     body: list[Statement]
 
@@ -493,29 +495,26 @@ class AsyncBlock(Statement):
     """
     Asynchronous block for executing a computation asynchronously.
     """
+    completion_name: Completion
     body: list[Statement]
-    completion_name: Optional[Completion] = None
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
         body_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.body)
-        if self.completion_name:
-            return f'{indent_str}{self.completion_name.as_ir()} = async {{\n{body_str}\n{indent_str}}}'
-        else:
-            return f'{indent_str}async {{\n{body_str}\n{indent_str}}}'
+        return f'{indent_str}{self.completion_name.as_ir()} = async {{\n{body_str}\n{indent_str}}}'
 
 
 # Await Completion Statement
 @dataclass
-class AwaitStatement(Statement):
+class AwaitCompletionStatement(Statement):
     """
     Await statement to wait for a completion.
     """
-    completion: Completion
+    completion_name: Identifier
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
-        return f'{indent_str}await {self.completion.name.as_ir()}'
+        return f'{indent_str}await {self.completion_name.as_ir()}'
 
 
 # Assignment Statement
@@ -563,12 +562,12 @@ class ComputeBlock(SpatialNode):
     """
     The 'compute' block for defining computation on a subgrid of PEs.
     """
-    variables: list[Identifier]
+    variables: list[TypedIdentifier]
     subgrid: SubgridExpression
     statements: list[Statement]
 
     def validate(self) -> None:
-        assert all(isinstance(var, Identifier) for var in self.variables)
+        assert all(isinstance(var, TypedIdentifier) for var in self.variables)
         assert all(isinstance(stmt, Statement) for stmt in self.statements)
         assert len(self.variables) == 2
 

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -676,7 +676,6 @@ class ScopedNodeVisitor(visitor.ScopedIRNodeVisitor[SpatialNode]):
 
     def __init__(self, *args, **kwargs):
         super().__init__(SpatialNode, *args, **kwargs)
-        self._setup_scope_nodes(Kernel, Phase, ComputeBlock, DataflowBlock, PlaceBlock)
 
     def visit_Kernel(self, node: Kernel):
         return self._visit_ScopeNode(node)

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -425,23 +425,24 @@ class ForeachStatement(Statement):
     """
     variables: list[TypedIdentifier]
     parameter_range: list[RangeExpression]
+    stream_variable: Identifier
     receive_stream: Identifier
     body: list[Statement]
     completion_name: Optional[Completion] = None
 
     def validate(self) -> None:
-        assert len(self.variables) == len(self.parameter_range) + 1
+        assert len(self.variables) == len(self.parameter_range)
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
-        vars_str = ", ".join(var.as_ir() for var in self.variables)
+        vars_str = ", ".join(var.as_ir() for var in self.variables + [self.stream_variable])
         rng_str = ", ".join(rng.as_ir() for rng in self.parameter_range)
         body_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.body)
 
         if self.parameter_range:
-            main_str = f'foreach {vars_str} in [{rng_str}, receive({self.receive_stream.as_ir()})] {{\n{body_str}\n{indent_str}}}'
+            main_str = f'foreach {vars_str} in [{rng_str}], receive({self.receive_stream.as_ir()}) {{\n{body_str}\n{indent_str}}}'
         else:
-            main_str = f'foreach {vars_str} in [receive({self.receive_stream.as_ir()})] {{\n{body_str}\n{indent_str}}}'
+            main_str = f'foreach {vars_str} in receive({self.receive_stream.as_ir()}) {{\n{body_str}\n{indent_str}}}'
 
         if self.completion_name:
             return f'{indent_str}{self.completion_name.as_ir()} = {main_str}'

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -11,6 +11,14 @@ class SpatialNode(BaseNode):
     Base class for all spatial IR nodes.
     """
 
+    @classmethod
+    def from_lark(cls, args):
+        """
+        Simple constructor that calls the IR node object constructor with the
+        IR children in order. See ``lark_to_ir.py`` for usage.
+        """
+        return cls(*args)
+
     def as_ir(self, indent: int = 0) -> str:
         raise NotImplementedError()
 
@@ -51,6 +59,8 @@ class Identifier(SpatialNode):
     version: int
 
     def as_ir(self, indent: int = 0) -> str:
+        if self.version == 0:
+            return self.name
         return f'{self.name}#{self.version}'
 
 
@@ -73,16 +83,31 @@ class ArrayType(SpatialNode, IRType):
     An array type of a scalar or stream, with one or more dimensions.
     """
     base_type: Union[ScalarType, StreamType]
-    shape: list[Union[int, Parameter]]
+    shape: list[Union[int, 'Expression']]
 
     def validate(self) -> None:
         assert isinstance(self.shape, list)
-        assert all(isinstance(dim, (int, Parameter)) for dim in self.shape)
+        assert all(isinstance(dim, (int, Expression)) for dim in self.shape)
         assert len(self.shape) > 0
 
     def as_ir(self, indent: int = 0) -> str:
         dims = ", ".join(str(dim.as_ir() if isinstance(dim, SpatialNode) else dim) for dim in self.shape)
         return f'{self.base_type.as_ir()}[{dims}]'
+
+
+@dataclass
+class TypedIdentifier(SpatialNode):
+    """
+    A variable identifier (e.g., x, y, my_variable) with a type.
+    """
+    dtype: Union[ScalarType, StreamType, ArrayType]
+    name: str
+    version: int
+
+    def as_ir(self, indent: int = 0) -> str:
+        if self.version == 0:
+            return f'{self.dtype.as_ir()} {self.name}'
+        return f'{self.dtype.as_ir()} {self.name}#{self.version}'
 
 
 # Unary Operators
@@ -142,17 +167,17 @@ class ArraySlice(SpatialNode):
     For stride access: array[start:end:stride]
     """
     array: Identifier
-    indices: list[Union[int, Identifier, 'RangeExpression']]  # Handles single-index or ranges
+    indices: list[Union['Expression', 'RangeExpression']]  # Handles single-index or ranges
 
     def validate(self) -> None:
         assert isinstance(self.array, Identifier)
         assert isinstance(self.indices, list)
-        assert all(isinstance(idx, (int, Identifier, RangeExpression)) for idx in self.indices)
+        assert all(isinstance(idx, (Expression, RangeExpression)) for idx in self.indices)
 
     def as_ir(self, indent: int = 0) -> str:
         index_strs = []
         for idx in self.indices:
-            if isinstance(idx, (RangeExpression, Identifier)):
+            if isinstance(idx, (RangeExpression, Expression)):
                 index_strs.append(idx.as_ir())
             elif isinstance(idx, int):
                 index_strs.append(str(idx))
@@ -166,13 +191,11 @@ class Expression(SpatialNode):
     A general expression that can take the form of an identifier, literal, array slice, unary/binary operator, etc.
     """
     value: Union[Identifier, ConstantLiteral, Parameter, ArraySlice, UnaryOperator, BinaryOperator, TernaryOperator]
-    dtype: ScalarType
 
     def validate(self) -> None:
         assert isinstance(
             self.value,
             (Identifier, ConstantLiteral, Parameter, ArraySlice, UnaryOperator, BinaryOperator, TernaryOperator))
-        assert isinstance(self.dtype, ScalarType)
 
     def as_ir(self, indent: int = 0) -> str:
         return self.value.as_ir()
@@ -282,7 +305,7 @@ class RelativeStreamDeclaration(SpatialNode):
     A stream declaration inside a dataflow block that declares a communication stream
     to and from PEs at relative positions, with an optional routing declaration.
     """
-    dtype: StreamType
+    dtype: ScalarType
     stream_name: Identifier
     dx: Expression
     dy: Expression
@@ -293,7 +316,7 @@ class RelativeStreamDeclaration(SpatialNode):
         routing_str = ""
         if self.routing:
             routing_str = f" {{\n{self.routing.as_ir(indent + 1)}\n{' ' * indent}}}"
-        return f'{indent_str}stream<{self.dtype.element_type.as_ir()}> {self.stream_name.as_ir()} = relative_stream({self.dx.as_ir()}, {self.dy.as_ir()}){routing_str}'
+        return f'{indent_str}stream<{self.dtype.as_ir()}> {self.stream_name.as_ir()} = relative_stream({self.dx.as_ir()}, {self.dy.as_ir()}){routing_str}'
 
 
 ###
@@ -366,11 +389,27 @@ class SendStatement(Statement):
         return f'{indent_str}send({self.local_array.as_ir()}, {self.stream_name.as_ir()})'
 
 
+@dataclass
+class ReceiveStatement(Statement):
+    """
+    Receive statement for receiving data asynchronously through a stream.
+    """
+    local_array: Union[Identifier, ArraySlice]
+    stream_name: Identifier
+    completion_name: Optional[Completion] = None
+
+    def as_ir(self, indent: int = 0) -> str:
+        indent_str = '  ' * indent
+        if self.completion_name:
+            return f'{indent_str}{self.completion_name.as_ir()} = receive({self.local_array.as_ir()}, {self.stream_name.as_ir()})'
+        return f'{indent_str}receive({self.local_array.as_ir()}, {self.stream_name.as_ir()})'
+
+
 # Receive Statement
 @dataclass
 class Receive(SpatialNode):
     """
-    Receive data from a stream.
+    Receive data from a stream, used in a foreach statement.
     """
     stream_name: Identifier
 
@@ -389,17 +428,18 @@ class ForeachStatement(Statement):
     receive_stream: Receive
     body: list[Statement]
     completion_name: Optional[Completion] = None
-    parameter_range: Optional[RangeExpression] = None
+    parameter_range: Optional[list[RangeExpression]] = None
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
         vars_str = ", ".join(var.as_ir() for var in self.variables)
+        rng_str = ", ".join(rng.as_ir() for rng in self.parameter_range)
         body_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.body)
 
         if self.parameter_range:
-            main_str = f'foreach {vars_str} in [{self.parameter_range.as_ir()}, {self.receive_stream.as_ir()}] {{\n{body_str}\n{indent_str}}}'
+            main_str = f'foreach {vars_str} in [{rng_str}, receive({self.receive_stream.as_ir()})] {{\n{body_str}\n{indent_str}}}'
         else:
-            main_str = f'foreach {vars_str} in [{self.receive_stream.as_ir()}] {{\n{body_str}\n{indent_str}}}'
+            main_str = f'foreach {vars_str} in [receive({self.receive_stream.as_ir()})] {{\n{body_str}\n{indent_str}}}'
 
         if self.completion_name:
             return f'{indent_str}{self.completion_name.as_ir()} = {main_str}'
@@ -414,15 +454,19 @@ class MapStatement(Statement):
     Map statement for applying an affine computation asynchronously to array elements.
     """
     variables: list[Identifier]
-    range_expression: RangeExpression
+    range_expression: list[RangeExpression]
     body: list[Statement]
     completion_name: Optional[Completion] = None
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
         vars_str = ", ".join(var.as_ir() for var in self.variables)
+        rng_str = ", ".join(rng.as_ir() for rng in self.range_expression)
         body_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.body)
-        return f'{indent_str}{self.completion_name.as_ir()} = map {vars_str} in [{self.range_expression.as_ir()}] {{\n{body_str}\n{indent_str}}}'
+        if self.completion_name:
+            return f'{indent_str}{self.completion_name.as_ir()} = map {vars_str} in [{rng_str}] {{\n{body_str}\n{indent_str}}}'
+        else:
+            return f'{indent_str}await map {vars_str} in [{rng_str}] {{\n{body_str}\n{indent_str}}}'
 
 
 # Sequential For Loop
@@ -432,14 +476,15 @@ class ForStatement(Statement):
     Sequential for loop for iterating over a range expression.
     """
     variables: list[Identifier]
-    range_expression: RangeExpression
+    range_expression: list[RangeExpression]
     body: list[Statement]
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
         vars_str = ", ".join(var.as_ir() for var in self.variables)
+        rng_str = ", ".join(rng.as_ir() for rng in self.range_expression)
         body_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.body)
-        return f'{indent_str}for {vars_str} in [{self.range_expression.as_ir()}] {{\n{body_str}\n{indent_str}}}'
+        return f'{indent_str}for {vars_str} in [{rng_str}] {{\n{body_str}\n{indent_str}}}'
 
 
 # Asynchronous Block
@@ -454,7 +499,10 @@ class AsyncBlock(Statement):
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
         body_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.body)
-        return f'{indent_str}{self.completion_name.as_ir()} = async {{\n{body_str}\n{indent_str}}}'
+        if self.completion_name:
+            return f'{indent_str}{self.completion_name.as_ir()} = async {{\n{body_str}\n{indent_str}}}'
+        else:
+            return f'{indent_str}async {{\n{body_str}\n{indent_str}}}'
 
 
 # Await Completion Statement
@@ -467,7 +515,7 @@ class AwaitStatement(Statement):
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
-        return f'{indent_str}await {self.completion.as_ir()}'
+        return f'{indent_str}await {self.completion.name.as_ir()}'
 
 
 # Assignment Statement
@@ -478,8 +526,8 @@ class AssignmentStatement(Statement):
     """
     Assigns the result of an expression to a field or variable
     """
-    source: Expression
     destination: ArraySlice | Identifier
+    source: Expression
 
     def validate(self) -> None:
         assert isinstance(self.source, Expression)
@@ -488,6 +536,25 @@ class AssignmentStatement(Statement):
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
         return f'{indent_str}{self.destination.as_ir()} = {self.source.as_ir()}'
+
+
+@dataclass
+class DefinitionStatement(Statement):
+    """
+    Assigns the result of an expression to a field or variable
+    """
+    dtype: Union[ScalarType, StreamType]
+    destination: Identifier
+    source: Expression
+
+    def validate(self) -> None:
+        assert isinstance(self.source, Expression)
+        assert isinstance(self.destination, (ArraySlice, Identifier))
+        assert isinstance(self.dtype, (ScalarType, StreamType))
+
+    def as_ir(self, indent: int = 0) -> str:
+        indent_str = '  ' * indent
+        return f'{indent_str}{self.dtype.as_ir()} {self.destination.as_ir()} = {self.source.as_ir()}'
 
 
 # Compute Block

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Union, Tuple, Optional, Literal
+from spatialstencil.syntax.common import visitor
 from spatialstencil.syntax.common.basenode import BaseNode
 from spatialstencil.syntax.common.types import ScalarType, IRType
 
@@ -114,7 +115,21 @@ class BinaryOperator(SpatialNode):
         assert self.op in ('+', '-', '*', '/', '//', '%', '==', '!=', '<', '<=', '>', '>=')
 
     def as_ir(self, indent: int = 0) -> str:
-        return f'{self.left.as_ir()} {self.op} {self.right.as_ir()}'
+        return f'({self.left.as_ir()} {self.op} {self.right.as_ir()})'
+
+
+# Ternary Operator
+@dataclass
+class TernaryOperator(SpatialNode):
+    """
+    A ternary operator (``x ? y : z`` in C or ``y if x else z`` in Python).
+    """
+    cond: 'Expression'
+    if_true: 'Expression'
+    if_false: 'Expression'
+
+    def as_ir(self, indent: int = 0) -> str:
+        return f'({self.if_true.as_ir()} if {self.cond.as_ir()} else {self.if_false.as_ir()})'
 
 
 # ArraySlice to handle both subscripts (single index access) and array slices (start:end)
@@ -150,12 +165,13 @@ class Expression(SpatialNode):
     """
     A general expression that can take the form of an identifier, literal, array slice, unary/binary operator, etc.
     """
-    value: Union[Identifier, ConstantLiteral, Parameter, ArraySlice, UnaryOperator, BinaryOperator]
+    value: Union[Identifier, ConstantLiteral, Parameter, ArraySlice, UnaryOperator, BinaryOperator, TernaryOperator]
     dtype: ScalarType
 
     def validate(self) -> None:
-        assert isinstance(self.value,
-                          (Identifier, ConstantLiteral, Parameter, ArraySlice, UnaryOperator, BinaryOperator))
+        assert isinstance(
+            self.value,
+            (Identifier, ConstantLiteral, Parameter, ArraySlice, UnaryOperator, BinaryOperator, TernaryOperator))
         assert isinstance(self.dtype, ScalarType)
 
     def as_ir(self, indent: int = 0) -> str:
@@ -578,3 +594,40 @@ class Kernel(SpatialNode):
         body_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.body)
         return f'kernel @{self.name}<{param_str}>({arg_str}) {{\n{body_str}\n}}' if self.name \
             else f'kernel<{param_str}>({arg_str}) {{\n{body_str}\n}}'
+
+
+# Specialized visitors
+
+
+class NodeVisitor(visitor.IRNodeVisitor[SpatialNode]):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(SpatialNode, *args, **kwargs)
+
+
+class ScopedNodeVisitor(visitor.ScopedIRNodeVisitor[SpatialNode]):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(SpatialNode, *args, **kwargs)
+        self._setup_scope_nodes(Kernel, Phase, ComputeBlock, DataflowBlock, PlaceBlock)
+
+    def visit_Kernel(self, node: Kernel):
+        return self._visit_ScopeNode(node)
+
+    def visit_Phase(self, node: Phase):
+        return self._visit_ScopeNode(node)
+
+    def visit_ComputeBlock(self, node: ComputeBlock):
+        return self._visit_ScopeNode(node)
+
+    def visit_DataflowBlock(self, node: DataflowBlock):
+        return self._visit_ScopeNode(node)
+
+    def visit_PlaceBlock(self, node: PlaceBlock):
+        return self._visit_ScopeNode(node)
+
+
+class NodeTransformer(visitor.IRNodeTransformer[SpatialNode]):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(SpatialNode, *args, **kwargs)

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -32,6 +32,10 @@ class ConstantLiteral(SpatialNode):
     value: Union[int, float]
     dtype: ScalarType
 
+    def validate(self) -> None:
+        assert isinstance(self.value, (int, float))
+        assert isinstance(self.dtype, ScalarType)
+
     def as_ir(self, indent: int = 0) -> str:
         return str(self.value)
 
@@ -45,6 +49,11 @@ class Parameter(SpatialNode):
     name: str
     value: Optional[int] = None
 
+    def validate(self) -> None:
+        assert isinstance(self.name, str)
+        if self.value is not None:
+            assert isinstance(self.value, int)
+
     def as_ir(self, indent: int = 0) -> str:
         return self.name
 
@@ -57,6 +66,10 @@ class Identifier(SpatialNode):
     """
     name: str
     version: int
+
+    def validate(self) -> None:
+        assert isinstance(self.name, str)
+        assert isinstance(self.version, int)
 
     def as_ir(self, indent: int = 0) -> str:
         if self.version == 0:
@@ -106,6 +119,10 @@ class TypedIdentifier(SpatialNode):
     dtype: Union[ScalarType, StreamType, ArrayType]
     identifier: Identifier
 
+    def validate(self) -> None:
+        assert isinstance(self.dtype, (ScalarType, StreamType, ArrayType))
+        assert isinstance(self.identifier, Identifier)
+
     def as_ir(self, indent: int = 0) -> str:
         return f'{self.dtype.as_ir()} {self.identifier.as_ir()}'
 
@@ -121,6 +138,7 @@ class UnaryOperator(SpatialNode):
 
     def validate(self) -> None:
         assert self.op in ('+', '-')
+        assert isinstance(self.value, Expression)
 
     def as_ir(self, indent: int = 0) -> str:
         return f'{self.op}{self.value.as_ir()}'
@@ -138,6 +156,8 @@ class BinaryOperator(SpatialNode):
 
     def validate(self) -> None:
         assert self.op in ('+', '-', '*', '/', '//', '%', '==', '!=', '<', '<=', '>', '>=')
+        assert isinstance(self.left, Expression)
+        assert isinstance(self.right, Expression)
 
     def as_ir(self, indent: int = 0) -> str:
         return f'({self.left.as_ir()} {self.op} {self.right.as_ir()})'
@@ -152,6 +172,11 @@ class TernaryOperator(SpatialNode):
     cond: 'Expression'
     if_true: 'Expression'
     if_false: 'Expression'
+
+    def validate(self) -> None:
+        assert isinstance(self.cond, Expression)
+        assert isinstance(self.if_true, Expression)
+        assert isinstance(self.if_false, Expression)
 
     def as_ir(self, indent: int = 0) -> str:
         return f'({self.if_true.as_ir()} if {self.cond.as_ir()} else {self.if_false.as_ir()})'
@@ -230,6 +255,10 @@ class SubgridExpression(SpatialNode):
     x_range: RangeExpression
     y_range: RangeExpression
 
+    def validate(self) -> None:
+        assert isinstance(self.x_range, RangeExpression)
+        assert isinstance(self.y_range, RangeExpression)
+
     def as_ir(self, indent: int = 0) -> str:
         return f'[{self.x_range.as_ir()} , {self.y_range.as_ir()}]'
 
@@ -263,6 +292,14 @@ class PlaceBlock(SpatialNode):
     variables: list[TypedIdentifier]
     subgrid: SubgridExpression
     statements: list[FieldDeclaration]
+
+    def validate(self) -> None:
+        assert isinstance(self.subgrid, SubgridExpression)
+        assert isinstance(self.variables, list)
+        assert isinstance(self.statements, list)
+        assert all(isinstance(var, TypedIdentifier) for var in self.variables)
+        assert all(isinstance(stmt, FieldDeclaration) for stmt in self.statements)
+        assert len(self.variables) == 2
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
@@ -310,6 +347,14 @@ class RelativeStreamDeclaration(SpatialNode):
     dx: Expression
     dy: Expression
     routing: Optional[RoutingDeclaration] = None
+
+    def validate(self) -> None:
+        assert isinstance(self.dtype, StreamType)
+        assert isinstance(self.stream_name, Identifier)
+        assert isinstance(self.dx, Expression)
+        assert isinstance(self.dy, Expression)
+        if self.routing:
+            assert isinstance(self.routing, RoutingDeclaration)
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
@@ -367,6 +412,9 @@ class Completion(SpatialNode):
     """
     name: Identifier
 
+    def validate(self) -> None:
+        assert isinstance(self.name, Identifier)
+
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
         return f'{indent_str}completion {self.name.as_ir()}'
@@ -379,8 +427,14 @@ class SendStatement(Statement):
     Send statement for sending data asynchronously through a stream.
     """
     local_array: Union[Identifier, ArraySlice]
-    stream_name: Identifier
+    stream_name: Union[Identifier, ArraySlice]
     completion_name: Optional[Completion] = None
+
+    def validate(self) -> None:
+        assert isinstance(self.local_array, (Identifier, ArraySlice))
+        assert isinstance(self.stream_name, (Identifier, ArraySlice))
+        if self.completion_name:
+            assert isinstance(self.completion_name, Completion)
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
@@ -395,8 +449,14 @@ class ReceiveStatement(Statement):
     Receive statement for receiving data asynchronously through a stream.
     """
     local_array: Union[Identifier, ArraySlice]
-    stream_name: Identifier
+    stream_name: Union[Identifier, ArraySlice]
     completion_name: Optional[Completion] = None
+
+    def validate(self) -> None:
+        assert isinstance(self.local_array, (Identifier, ArraySlice))
+        assert isinstance(self.stream_name, (Identifier, ArraySlice))
+        if self.completion_name:
+            assert isinstance(self.completion_name, Completion)
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
@@ -413,6 +473,9 @@ class ReceiveGenerator(SpatialNode):
     """
     stream_name: Identifier
 
+    def validate(self) -> None:
+        assert isinstance(self.stream_name, Identifier)
+
     def as_ir(self, indent: int = 0) -> str:
         return f'receive({self.stream_name.as_ir()})'
 
@@ -425,13 +488,18 @@ class ForeachStatement(Statement):
     """
     variables: list[TypedIdentifier]
     parameter_range: list[RangeExpression]
-    stream_variable: Identifier
+    stream_variable: TypedIdentifier
     receive_stream: ReceiveGenerator
     body: list[Statement]
     completion_name: Optional[Completion] = None
 
     def validate(self) -> None:
         assert len(self.variables) == len(self.parameter_range)
+        assert all(isinstance(var, TypedIdentifier) for var in self.variables)
+        assert all(isinstance(rng, RangeExpression) for rng in self.parameter_range)
+        assert isinstance(self.stream_variable, TypedIdentifier)
+        assert isinstance(self.receive_stream, ReceiveGenerator)
+        assert all(isinstance(stmt, Statement) for stmt in self.body)
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
@@ -461,6 +529,16 @@ class MapStatement(Statement):
     body: list[Statement]
     completion_name: Optional[Completion] = None
 
+    def validate(self) -> None:
+        assert isinstance(self.variables, list)
+        assert isinstance(self.range_expression, list)
+        assert len(self.variables) == len(self.range_expression)
+        assert all(isinstance(var, TypedIdentifier) for var in self.variables)
+        assert all(isinstance(rng, RangeExpression) for rng in self.range_expression)
+        assert all(isinstance(stmt, Statement) for stmt in self.body)
+        if self.completion_name:
+            assert isinstance(self.completion_name, Completion)
+
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
         vars_str = ", ".join(var.as_ir() for var in self.variables)
@@ -482,6 +560,12 @@ class ForStatement(Statement):
     range_expression: list[RangeExpression]
     body: list[Statement]
 
+    def validate(self) -> None:
+        assert len(self.variables) == len(self.range_expression)
+        assert all(isinstance(var, TypedIdentifier) for var in self.variables)
+        assert all(isinstance(rng, RangeExpression) for rng in self.range_expression)
+        assert all(isinstance(stmt, Statement) for stmt in self.body)
+
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
         vars_str = ", ".join(var.as_ir() for var in self.variables)
@@ -499,6 +583,11 @@ class AsyncBlock(Statement):
     completion_name: Completion
     body: list[Statement]
 
+    def validate(self) -> None:
+        assert isinstance(self.completion_name, Completion)
+        assert isinstance(self.body, list)
+        assert all(isinstance(stmt, Statement) for stmt in self.body)
+
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
         body_str = "\n".join(stmt.as_ir(indent + 1) for stmt in self.body)
@@ -512,6 +601,9 @@ class AwaitCompletionStatement(Statement):
     Await statement to wait for a completion.
     """
     completion_name: Identifier
+
+    def validate(self) -> None:
+        assert isinstance(self.completion_name, Identifier)
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
@@ -549,6 +641,9 @@ class ComputeBlock(SpatialNode):
     statements: list[Statement]
 
     def validate(self) -> None:
+        assert isinstance(self.subgrid, SubgridExpression)
+        assert isinstance(self.variables, list)
+        assert isinstance(self.statements, list)
         assert all(isinstance(var, TypedIdentifier) for var in self.variables)
         assert all(isinstance(stmt, Statement) for stmt in self.statements)
         assert len(self.variables) == 2
@@ -573,6 +668,14 @@ class Phase(SpatialNode):
     place: list[PlaceBlock]
     dataflow: list[DataflowBlock]
     compute: list[ComputeBlock]
+
+    def validate(self) -> None:
+        assert isinstance(self.place, list)
+        assert isinstance(self.dataflow, list)
+        assert isinstance(self.compute, list)
+        assert all(isinstance(pl, PlaceBlock) for pl in self.place)
+        assert all(isinstance(df, DataflowBlock) for df in self.dataflow)
+        assert all(isinstance(cmp, ComputeBlock) for cmp in self.compute)
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
@@ -606,6 +709,8 @@ class KernelArgument(SpatialNode):
     def validate(self) -> None:
         assert isinstance(self.dtype, (ScalarType, ArrayType, StreamType))
         assert isinstance(self.identifier, Identifier)
+        assert not self.readonly or not self.writeonly
+        assert not self.compiletime or not self.writeonly
 
     def as_ir(self, indent: int = 0) -> str:
         annotations = []
@@ -632,6 +737,11 @@ class Kernel(SpatialNode):
     body: list[PlaceBlock | DataflowBlock | ComputeBlock | Phase]
 
     def validate(self) -> None:
+        if self.name:
+            assert isinstance(self.name, str)
+        assert isinstance(self.parameters, list)
+        assert isinstance(self.arguments, list)
+        assert isinstance(self.body, list)
         assert all(isinstance(p, Parameter) for p in self.parameters)
         assert all(isinstance(arg, KernelArgument) for arg in self.arguments)
         assert all(isinstance(stmt, (Phase, ComputeBlock, DataflowBlock, PlaceBlock)) for stmt in self.body)

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -72,6 +72,9 @@ class StreamType(SpatialNode, IRType):
     """
     dtype: ScalarType
 
+    def validate(self) -> None:
+        assert isinstance(self.dtype, ScalarType)
+
     def as_ir(self, indent: int = 0) -> str:
         return f'stream<{self.dtype.as_ir()}>'
 
@@ -302,7 +305,7 @@ class RelativeStreamDeclaration(SpatialNode):
     A stream declaration inside a dataflow block that declares a communication stream
     to and from PEs at relative positions, with an optional routing declaration.
     """
-    dtype: ScalarType
+    dtype: StreamType
     stream_name: Identifier
     dx: Expression
     dy: Expression
@@ -313,7 +316,7 @@ class RelativeStreamDeclaration(SpatialNode):
         routing_str = ""
         if self.routing:
             routing_str = f" {{\n{self.routing.as_ir(indent + 1)}\n{' ' * indent}}}"
-        return f'{indent_str}stream<{self.dtype.as_ir()}> {self.stream_name.as_ir()} = relative_stream({self.dx.as_ir()}, {self.dy.as_ir()}){routing_str}'
+        return f'{indent_str}stream<{self.dtype.dtype.as_ir()}> {self.stream_name.as_ir()} = relative_stream({self.dx.as_ir()}, {self.dy.as_ir()}){routing_str}'
 
 
 ###

--- a/spatialstencil/syntax/spatial_ir/language.lark
+++ b/spatialstencil/syntax/spatial_ir/language.lark
@@ -31,17 +31,16 @@ identifier : suffix_id ("#" digits)?
 !int_type : "i8" | "i16" | "i32"
 !uint_type : "u8" | "u16" | "u32"
 !bool_type : "bool"
-!object_type : "completion" | "relative_stream"
-!var_type : "var"
+!object_type : "completion"
 ?scalar_type : float_type | int_type | uint_type | bool_type
 stream_type : "stream" "<" scalar_type ">"
-?standard_type : scalar_type | object_type | var_type | stream_type
+?standard_type : scalar_type | object_type | stream_type
 
 // Array types
-?array_type : standard_type "[" value_expr ("," value_expr)* "]"
+array_type : standard_type "[" value_expr ("," value_expr)* "]"
 
 // Annotations
-annotation : "readonly" | "writeonly" | "compiletime"
+!annotation : "readonly" | "writeonly" | "compiletime"
 annotations : annotation (annotation)*
 
 ?builtin_type : array_type | standard_type
@@ -109,6 +108,7 @@ subscript : identifier "[" subscript_slice "]"
 
 range_expression : value_expr ":" value_expr (":" value_expr)?
 subgrid_expression : "[" range_expression ("," range_expression)* "]"
+subgrid_expression_2d : "[" range_expression "," range_expression "]"
 range_and_stream : "[" (range_expression ("," range_expression)* ",")? "receive" "(" identifier ")" "]"
 ///////////////////////////////////////////////////
 // Declarations and routing
@@ -119,7 +119,7 @@ hops : "[" hop ("," hop)* "]"
 routing : "hops" "=" (auto | hops) "," "channel" "=" (auto | integer_literal)
 
 field_declaration : builtin_type identifier  (";")? //(";" | NEWLINE)
-stream_declaration : "stream" "<" scalar_type ">" bare_id "=" "relative_stream" "(" value_expr "," value_expr ")" ("{" routing "}")?  (";")?
+stream_declaration : "stream" "<" scalar_type ">" identifier "=" "relative_stream" "(" value_expr "," value_expr ")" ("{" routing "}")?  (";")?
 vars : identifier ("," identifier)*
 typed_var : scalar_type identifier
 typed_vars : typed_var ("," typed_var)*
@@ -127,28 +127,35 @@ typed_vars : typed_var ("," typed_var)*
 ///////////////////////////////////////////////////
 // Scope contents
 
-// TODO
+// Free function call
 function_call: bare_id "(" [call_arguments] ")" 
 
-await_stmt : "await" (identifier | foreach_stmt | map_stmt | function_call)
+await_stmt : "await" identifier
+?await_foreach : "await" foreach_stmt
+?await_map : "await" map_stmt
+?await_function : "await" function_call
+?await : await_stmt | await_foreach | await_map | await_function
 
+// TODO: Define syntax
 if_stmt : "if"
 //if_op : "if" "(" identifier ")" type_info? computation_body (elif_block)* (else_block)?
 //elif_block : "elif" "(" identifier ")" computation_body
 //else_block : "else" computation_body
 
-for_stmt : "for"
-map_stmt : "map" typed_vars "in" subgrid_expression "{" (statement)* "}"
-foreach_stmt : "foreach" typed_vars "in" range_and_stream "{" (statement)* "}"
-async_stmt : "async" "{" (statement)* "}"
+scope_stmt_body :  "{" (statement)* "}" 
 
-?base_stmt : (function_call | await_stmt | map_stmt | foreach_stmt | async_stmt | for_stmt | if_stmt)
+for_stmt : "for" typed_vars "in" subgrid_expression scope_stmt_body
+map_stmt : "map" typed_vars "in" subgrid_expression scope_stmt_body
+foreach_stmt : "foreach" typed_vars "in" range_and_stream scope_stmt_body
+async_stmt : "async" scope_stmt_body
+
+?base_stmt : (function_call | await | map_stmt | foreach_stmt | async_stmt | for_stmt | if_stmt)
 ?rhs : (value_expr | function_call | map_stmt | foreach_stmt | async_stmt)
 
 definition : builtin_type identifier "=" rhs
 assignment : (subscript | identifier) "=" rhs
 
-statement : (definition | assignment | base_stmt) (";")?
+?statement : (definition | assignment | base_stmt) (";")?
 
 
 ////////////////////////////////////////////////////
@@ -156,14 +163,14 @@ statement : (definition | assignment | base_stmt) (";")?
 
 // Kernel
 parameters : "<" (bare_id ("," bare_id)*)? ">"
-typed_argument : builtin_type bare_id annotations?
+typed_argument : builtin_type annotations? bare_id
 arguments : "(" (typed_argument ("," typed_argument)*)? ")"
 kernel : "kernel" ("@" bare_id)? parameters arguments kernel_body
 
 // Kernel contents
-place_block : "place" vars "in" subgrid_expression place_body
-dataflow_block : "dataflow" vars "in" subgrid_expression dataflow_body
-compute_block : "compute" vars "in" subgrid_expression compute_body
+place_block : "place" vars "in" subgrid_expression_2d place_body
+dataflow_block : "dataflow" vars "in" subgrid_expression_2d dataflow_body
+compute_block : "compute" vars "in" subgrid_expression_2d compute_body
 phase : "phase" phase_body
 
 ////////////////////////////////////////////////////

--- a/spatialstencil/syntax/spatial_ir/language.lark
+++ b/spatialstencil/syntax/spatial_ir/language.lark
@@ -157,10 +157,9 @@ async_stmt : completion "async" compute_body
 // Top-level statements that are direct children of `compute` blocks
 ?base_stmt : (function_call | await_completion | map_stmt | foreach_stmt | async_stmt | for_stmt)
 
-definition : builtin_type identifier "=" value_expr
 assignment : (subscript | identifier) "=" value_expr
 
-?statement : (definition | assignment | base_stmt)
+?statement : (assignment | base_stmt)
 
 
 ////////////////////////////////////////////////////

--- a/spatialstencil/syntax/spatial_ir/language.lark
+++ b/spatialstencil/syntax/spatial_ir/language.lark
@@ -108,7 +108,6 @@ subscript : identifier "[" subscript_slice "]"
 range_expression : value_expr ":" value_expr (":" value_expr)?
 subgrid_expression : "[" range_expression ("," range_expression)* "]"
 subgrid_expression_2d : "[" range_expression "," range_expression "]"
-range_and_stream : "[" (range_expression ("," range_expression)* ",")? "receive" "(" (identifier | subscript) ")" "]"
 ///////////////////////////////////////////////////
 // Declarations and routing
 
@@ -122,6 +121,14 @@ stream_declaration : "stream" "<" scalar_type ">" identifier "=" "relative_strea
 vars : identifier ("," identifier)*
 typed_var : scalar_type identifier
 typed_vars : typed_var ("," typed_var)*
+
+///////////////////////////////////////////////////
+// Generators for foreach statements
+
+receive_generator : "receive" "(" (identifier | subscript) ")"
+
+?generator : receive_generator | subgrid_expression
+generators : generator ("," generator)*
 
 ///////////////////////////////////////////////////
 // Scope contents
@@ -144,7 +151,7 @@ await_completion : "await" identifier
 
 for_stmt : "for" typed_vars "in" subgrid_expression compute_body
 map_stmt : prefix "map" typed_vars "in" subgrid_expression compute_body
-foreach_stmt : prefix "foreach" typed_vars "in" range_and_stream compute_body
+foreach_stmt : prefix "foreach" typed_vars "in" generators compute_body
 async_stmt : completion "async" compute_body
 
 // Top-level statements that are direct children of `compute` blocks

--- a/spatialstencil/syntax/spatial_ir/language.lark
+++ b/spatialstencil/syntax/spatial_ir/language.lark
@@ -1,0 +1,186 @@
+////////////////////////////////////////////////////
+// Low-level literal syntax
+digit      : /[0-9]/
+digits     : /[0-9]+/
+hex_digit  : /[0-9a-fA-F]/
+hex_digits : /[0-9a-fA-F]+/
+letter     : /[a-zA-Z]/
+letters    : /[a-zA-Z]+/
+underscore : /[_]/
+true       : "true"
+false      : "false"
+
+// Literals
+bool_literal : true | false
+decimal_literal : digits
+hexadecimal_literal : "0x" hex_digits
+?integer_literal : decimal_literal | hexadecimal_literal
+negated_integer_literal : "-" integer_literal
+?posneg_integer_literal : integer_literal | negated_integer_literal
+float_literal : /[-+]?[0-9]+[.][0-9]*([eE][-+]?[0-9]+)?/
+string_literal  : ESCAPED_STRING
+?constant_literal : bool_literal | posneg_integer_literal | float_literal | string_literal
+
+// Identifier syntax (loosely following MLIR conventions)
+bare_id : (letter| underscore) (letter|digit|underscore)*
+suffix_id : digits | bare_id
+identifier : suffix_id ("#" digits)?
+
+// Scalar types
+!float_type : "f16" | "f32" | "f64"
+!int_type : "i8" | "i16" | "i32"
+!uint_type : "u8" | "u16" | "u32"
+!bool_type : "bool"
+!object_type : "completion" | "stream" | "relative_stream"
+!var_type : "var"
+?scalar_type : float_type | int_type | uint_type | bool_type
+?standard_type : scalar_type | object_type | var_type
+
+// Array types
+?array_type : standard_type "[" (integer_literal | bare_id) ("," (integer_literal | bare_id))* "]"
+
+// Annotations
+annotation : "readonly" | "writeonly" | "compiletime"
+annotations : annotation (annotation)*
+
+?builtin_type : array_type | standard_type
+
+////////////////////////////////////////////////////
+// Operators and operator precedence
+// Adapted and reduced from Lark's Python grammar
+// https://github.com/lark-parser/lark/blob/88fe0fdcdccc9f8856e96fd6fe9d28ae3cb4f64b/lark/grammars/python.lark
+
+?test : or_test
+      | or_test "if" or_test "else" test -> ternary_op
+
+?or_test: and_test ("or" or_test) -> binary_op_logical_or
+        | and_test
+?and_test: not_test_ ("and" and_test) -> binary_op_logical_and
+         | not_test_
+?not_test_: "not" not_test_ -> not_test
+          | comparison
+?comparison: expr (_comp_op comparison) -> comparison
+           | expr
+
+?expr: or_expr
+?or_expr: xor_expr ("|" or_expr) -> binary_op_or
+        | xor_expr
+?xor_expr: and_expr ("^" xor_expr) -> binary_op_xor
+         | and_expr
+?and_expr: shift_expr ("&" and_expr) -> binary_op_and
+         | shift_expr
+?shift_expr: arith_expr (_shift_op shift_expr) -> binary_op
+           | arith_expr
+
+?arith_expr: term (_add_op arith_expr) -> binary_op
+           | term
+?term: factor (_mul_op term) -> binary_op
+     | factor
+?factor: _unary_op factor -> unary_op
+       | power
+
+!_unary_op: "+"|"-"|"~"
+!_add_op: "+"|"-"
+!_shift_op: "<<"|">>"
+!_mul_op: "*"|"/"|"%"
+!_comp_op: "<"|">"|"=="|">="|"<="|"!="
+
+?power: atom_expr ("**" factor)+ -> binary_op_pow
+      | atom_expr
+
+?atom_expr: bare_id "(" [call_arguments] ")"         -> call
+          | identifier "[" subscript_slice "]"  -> subscript
+          | atom_expr "." bare_id               -> getattr
+          | atom
+
+?atom: identifier
+     | constant_literal
+     | "(" test ")"
+
+value_expr : test     // Basic value type. See operator precedence for more information
+
+call_arguments: test ("," test)*
+subscript_slice : posneg_integer_literal ("," posneg_integer_literal)*
+
+///////////////////////////////////////////////////
+// Grid/Subgrid expressions
+
+range_expression : value_expr ":" value_expr (":" value_expr)?
+subgrid_expression : range_expression "," range_expression  // 2D at the moment, might expand
+
+///////////////////////////////////////////////////
+// Declarations and routing
+
+!auto : "auto"
+hop : "(" posneg_integer_literal "," posneg_integer_literal ")"  // 2D at the moment, might expand
+hops : "[" hop ("," hop)* "]"
+routing : "hops" "=" (auto | hops) "," "channel" "=" (auto | integer_literal)
+
+field_declaration : builtin_type identifier
+stream_declaration : "stream" "<" scalar_type ">" bare_id "=" "relative_stream" "(" value_expr "," value_expr ")" ("{" routing "}")?
+
+///////////////////////////////////////////////////
+// Scope contents
+
+// TODO
+function_call: bare_id "(" [call_arguments] ")" 
+
+await_stmt : "await" (identifier | foreach_stmt)
+
+if_stmt : "if"
+//if_op : "if" "(" identifier ")" type_info? computation_body (elif_block)* (else_block)?
+//elif_block : "elif" "(" identifier ")" computation_body
+//else_block : "else" computation_body
+
+for_stmt : "for"
+map_stmt : "map"
+foreach_stmt : "foreach"
+async_stmt : "async"
+
+?base_stmt : (value_expr | function_call | await_stmt)
+
+
+definition : builtin_type identifier "=" base_stmt
+assignment : identifier "=" base_stmt
+
+statement : (definition | assignment | base_stmt)
+
+
+////////////////////////////////////////////////////
+// Scopes
+
+// Kernel
+parameters : "<" (bare_id ("," bare_id)*)? ">"
+typed_argument : builtin_type bare_id annotations?
+arguments : "(" (typed_argument ("," typed_argument)*)? ")"
+kernel : "kernel" ("@" bare_id)? parameters arguments kernel_body
+
+// Kernel contents
+place_block : "place" vars "in" subgrid_expression place_body
+dataflow_block : "dataflow" vars "in" subgrid_expression dataflow_body
+compute_block : "compute" vars "in" subgrid_expression compute_body
+phase : "phase" phase_body
+
+////////////////////////////////////////////////////
+// AST structure
+kernel_body : "{" (place_block | dataflow_block | compute_block | phase)* "}"
+place_body : "{" field_declaration* "}"
+dataflow_body : "{" stream_declaration* "}"
+compute_body : "{" statement* "}"
+phase_body : "{" (place_block | dataflow_block | compute_block)* "}"
+
+?start: kernel
+
+////////////////////////////////////////////////////
+// Lark imports
+%import common.ESCAPED_STRING
+%import common.SIGNED_NUMBER
+%import common.WS
+%import common.NEWLINE
+
+// Things to ignore: whitespace, single-line comments, multi-line comments
+COMMENT : "//" /(.)+/ NEWLINE
+MULTILINE_COMMENT: /\/\*(\*(?!\/)|[^*])*\*\//
+%ignore WS
+%ignore COMMENT
+%ignore MULTILINE_COMMENT

--- a/spatialstencil/syntax/spatial_ir/language.lark
+++ b/spatialstencil/syntax/spatial_ir/language.lark
@@ -109,7 +109,7 @@ subscript : identifier "[" subscript_slice "]"
 range_expression : value_expr ":" value_expr (":" value_expr)?
 subgrid_expression : "[" range_expression ("," range_expression)* "]"
 subgrid_expression_2d : "[" range_expression "," range_expression "]"
-range_and_stream : "[" (range_expression ("," range_expression)* ",")? "receive" "(" identifier ")" "]"
+range_and_stream : "[" (range_expression ("," range_expression)* ",")? "receive" "(" (identifier | subscript) ")" "]"
 ///////////////////////////////////////////////////
 // Declarations and routing
 

--- a/spatialstencil/syntax/spatial_ir/language.lark
+++ b/spatialstencil/syntax/spatial_ir/language.lark
@@ -31,13 +31,14 @@ identifier : suffix_id ("#" digits)?
 !int_type : "i8" | "i16" | "i32"
 !uint_type : "u8" | "u16" | "u32"
 !bool_type : "bool"
-!object_type : "completion" | "stream" | "relative_stream"
+!object_type : "completion" | "relative_stream"
 !var_type : "var"
 ?scalar_type : float_type | int_type | uint_type | bool_type
-?standard_type : scalar_type | object_type | var_type
+stream_type : "stream" "<" scalar_type ">"
+?standard_type : scalar_type | object_type | var_type | stream_type
 
 // Array types
-?array_type : standard_type "[" (integer_literal | bare_id) ("," (integer_literal | bare_id))* "]"
+?array_type : standard_type "[" value_expr ("," value_expr)* "]"
 
 // Annotations
 annotation : "readonly" | "writeonly" | "compiletime"
@@ -89,7 +90,7 @@ annotations : annotation (annotation)*
       | atom_expr
 
 ?atom_expr: bare_id "(" [call_arguments] ")"         -> call
-          | identifier "[" subscript_slice "]"  -> subscript
+          | identifier "[" subscript_slice "]"  -> subscript_expr
           | atom_expr "." bare_id               -> getattr
           | atom
 
@@ -100,14 +101,15 @@ annotations : annotation (annotation)*
 value_expr : test     // Basic value type. See operator precedence for more information
 
 call_arguments: test ("," test)*
-subscript_slice : posneg_integer_literal ("," posneg_integer_literal)*
+subscript_slice : value_expr ("," value_expr)*
+subscript : identifier "[" subscript_slice "]"
 
 ///////////////////////////////////////////////////
 // Grid/Subgrid expressions
 
 range_expression : value_expr ":" value_expr (":" value_expr)?
-subgrid_expression : range_expression "," range_expression  // 2D at the moment, might expand
-
+subgrid_expression : "[" range_expression ("," range_expression)* "]"
+range_and_stream : "[" (range_expression ("," range_expression)* ",")? "receive" "(" identifier ")" "]"
 ///////////////////////////////////////////////////
 // Declarations and routing
 
@@ -116,8 +118,11 @@ hop : "(" posneg_integer_literal "," posneg_integer_literal ")"  // 2D at the mo
 hops : "[" hop ("," hop)* "]"
 routing : "hops" "=" (auto | hops) "," "channel" "=" (auto | integer_literal)
 
-field_declaration : builtin_type identifier
-stream_declaration : "stream" "<" scalar_type ">" bare_id "=" "relative_stream" "(" value_expr "," value_expr ")" ("{" routing "}")?
+field_declaration : builtin_type identifier  (";")? //(";" | NEWLINE)
+stream_declaration : "stream" "<" scalar_type ">" bare_id "=" "relative_stream" "(" value_expr "," value_expr ")" ("{" routing "}")?  (";")?
+vars : identifier ("," identifier)*
+typed_var : scalar_type identifier
+typed_vars : typed_var ("," typed_var)*
 
 ///////////////////////////////////////////////////
 // Scope contents
@@ -125,7 +130,7 @@ stream_declaration : "stream" "<" scalar_type ">" bare_id "=" "relative_stream" 
 // TODO
 function_call: bare_id "(" [call_arguments] ")" 
 
-await_stmt : "await" (identifier | foreach_stmt)
+await_stmt : "await" (identifier | foreach_stmt | map_stmt | function_call)
 
 if_stmt : "if"
 //if_op : "if" "(" identifier ")" type_info? computation_body (elif_block)* (else_block)?
@@ -133,17 +138,17 @@ if_stmt : "if"
 //else_block : "else" computation_body
 
 for_stmt : "for"
-map_stmt : "map"
-foreach_stmt : "foreach"
-async_stmt : "async"
+map_stmt : "map" typed_vars "in" subgrid_expression "{" (statement)* "}"
+foreach_stmt : "foreach" typed_vars "in" range_and_stream "{" (statement)* "}"
+async_stmt : "async" "{" (statement)* "}"
 
-?base_stmt : (value_expr | function_call | await_stmt)
+?base_stmt : (function_call | await_stmt | map_stmt | foreach_stmt | async_stmt | for_stmt | if_stmt)
+?rhs : (value_expr | function_call | map_stmt | foreach_stmt | async_stmt)
 
+definition : builtin_type identifier "=" rhs
+assignment : (subscript | identifier) "=" rhs
 
-definition : builtin_type identifier "=" base_stmt
-assignment : identifier "=" base_stmt
-
-statement : (definition | assignment | base_stmt)
+statement : (definition | assignment | base_stmt) (";")?
 
 
 ////////////////////////////////////////////////////

--- a/spatialstencil/syntax/spatial_ir/language.lark
+++ b/spatialstencil/syntax/spatial_ir/language.lark
@@ -31,10 +31,9 @@ identifier : suffix_id ("#" digits)?
 !int_type : "i8" | "i16" | "i32"
 !uint_type : "u8" | "u16" | "u32"
 !bool_type : "bool"
-!object_type : "completion"
 ?scalar_type : float_type | int_type | uint_type | bool_type
 stream_type : "stream" "<" scalar_type ">"
-?standard_type : scalar_type | object_type | stream_type
+?standard_type : scalar_type | stream_type
 
 // Array types
 array_type : standard_type "[" value_expr ("," value_expr)* "]"
@@ -127,17 +126,16 @@ typed_vars : typed_var ("," typed_var)*
 ///////////////////////////////////////////////////
 // Scope contents
 
+completion : "completion" identifier "="
+?prefix : completion | "await"
+
 // Free function call
-function_call: bare_id "(" [call_arguments] ")" 
+function_call: prefix bare_id "(" [call_arguments] ")" 
 
-await_stmt : "await" identifier
-?await_foreach : "await" foreach_stmt
-?await_map : "await" map_stmt
-?await_function : "await" function_call
-?await : await_stmt | await_foreach | await_map | await_function
+await_completion : "await" identifier
 
-// TODO: Define syntax
-if_stmt : "if"
+// TODO: Define syntax for branches
+// if_stmt : "if"
 //if_op : "if" "(" identifier ")" type_info? computation_body (elif_block)* (else_block)?
 //elif_block : "elif" "(" identifier ")" computation_body
 //else_block : "else" computation_body
@@ -145,15 +143,15 @@ if_stmt : "if"
 ?statements: statement? ((";" | NEWLINE)+ statement)* (";" | NEWLINE)*
 
 for_stmt : "for" typed_vars "in" subgrid_expression compute_body
-map_stmt : "map" typed_vars "in" subgrid_expression compute_body
-foreach_stmt : "foreach" typed_vars "in" range_and_stream compute_body
-async_stmt : "async" compute_body
+map_stmt : prefix "map" typed_vars "in" subgrid_expression compute_body
+foreach_stmt : prefix "foreach" typed_vars "in" range_and_stream compute_body
+async_stmt : completion "async" compute_body
 
-?base_stmt : (function_call | await | map_stmt | foreach_stmt | async_stmt | for_stmt | if_stmt)
-?rhs : (value_expr | function_call | map_stmt | foreach_stmt | async_stmt)
+// Top-level statements that are direct children of `compute` blocks
+?base_stmt : (function_call | await_completion | map_stmt | foreach_stmt | async_stmt | for_stmt)
 
-definition : builtin_type identifier "=" rhs
-assignment : (subscript | identifier) "=" rhs
+definition : builtin_type identifier "=" value_expr
+assignment : (subscript | identifier) "=" value_expr
 
 ?statement : (definition | assignment | base_stmt)
 
@@ -168,9 +166,9 @@ arguments : "(" (typed_argument ("," typed_argument)*)? ")"
 kernel : "kernel" ("@" bare_id)? parameters arguments kernel_body
 
 // Kernel contents
-place_block : "place" vars "in" subgrid_expression_2d place_body
-dataflow_block : "dataflow" vars "in" subgrid_expression_2d dataflow_body
-compute_block : "compute" vars "in" subgrid_expression_2d compute_body
+place_block : "place" typed_vars "in" subgrid_expression_2d place_body
+dataflow_block : "dataflow" typed_vars "in" subgrid_expression_2d dataflow_body
+compute_block : "compute" typed_vars "in" subgrid_expression_2d compute_body
 phase : "phase" phase_body
 
 ////////////////////////////////////////////////////

--- a/spatialstencil/syntax/spatial_ir/language.lark
+++ b/spatialstencil/syntax/spatial_ir/language.lark
@@ -142,12 +142,12 @@ if_stmt : "if"
 //elif_block : "elif" "(" identifier ")" computation_body
 //else_block : "else" computation_body
 
-scope_stmt_body :  "{" (statement)* "}" 
+?statements: statement? ((";" | NEWLINE)+ statement)* (";" | NEWLINE)*
 
-for_stmt : "for" typed_vars "in" subgrid_expression scope_stmt_body
-map_stmt : "map" typed_vars "in" subgrid_expression scope_stmt_body
-foreach_stmt : "foreach" typed_vars "in" range_and_stream scope_stmt_body
-async_stmt : "async" scope_stmt_body
+for_stmt : "for" typed_vars "in" subgrid_expression compute_body
+map_stmt : "map" typed_vars "in" subgrid_expression compute_body
+foreach_stmt : "foreach" typed_vars "in" range_and_stream compute_body
+async_stmt : "async" compute_body
 
 ?base_stmt : (function_call | await | map_stmt | foreach_stmt | async_stmt | for_stmt | if_stmt)
 ?rhs : (value_expr | function_call | map_stmt | foreach_stmt | async_stmt)
@@ -155,7 +155,7 @@ async_stmt : "async" scope_stmt_body
 definition : builtin_type identifier "=" rhs
 assignment : (subscript | identifier) "=" rhs
 
-?statement : (definition | assignment | base_stmt) (";")?
+?statement : (definition | assignment | base_stmt)
 
 
 ////////////////////////////////////////////////////
@@ -178,7 +178,7 @@ phase : "phase" phase_body
 kernel_body : "{" (place_block | dataflow_block | compute_block | phase)* "}"
 place_body : "{" field_declaration* "}"
 dataflow_body : "{" stream_declaration* "}"
-compute_body : "{" statement* "}"
+compute_body : "{" statements "}"
 phase_body : "{" (place_block | dataflow_block | compute_block)* "}"
 
 ?start: kernel

--- a/spatialstencil/syntax/spatial_ir/lark_to_ir.py
+++ b/spatialstencil/syntax/spatial_ir/lark_to_ir.py
@@ -181,8 +181,6 @@ class TreeToSpatialIR(lark.Transformer):
         if not other_gens:
             other_gens = [[]]
 
-        print(itervars, other_gens[0], iters[stream_varind], stream_gen, body)
-
         return irnodes.ForeachStatement(
             itervars, other_gens[0], iters[stream_varind], stream_gen, body, completion_name=completion)
 

--- a/spatialstencil/syntax/spatial_ir/lark_to_ir.py
+++ b/spatialstencil/syntax/spatial_ir/lark_to_ir.py
@@ -59,9 +59,7 @@ class TreeToSpatialIR(lark.Transformer):
                     return irnodes.Identifier(args[0], 0)
         return irnodes.Identifier(*args)
 
-    def typed_var(self, args):
-        dtype, ident = args
-        return irnodes.TypedIdentifier(dtype, ident.name, ident.version)
+    typed_var = irnodes.TypedIdentifier.from_lark
 
     float_type = int_type = uint_type = bool_type = lambda self, args: getattr(irnodes.ScalarType, str(args[0]))
     stream_type = irnodes.StreamType.from_lark
@@ -179,14 +177,13 @@ class TreeToSpatialIR(lark.Transformer):
             other_gens = [[]]
 
         return irnodes.ForeachStatement(
-            itervars, other_gens[0], iters[stream_varind], stream_gen.stream_name, body, completion_name=completion)
+            itervars, other_gens[0], iters[stream_varind], stream_gen, body, completion_name=completion)
 
     # Await for a completion object
     await_completion = irnodes.AwaitCompletionStatement.from_lark
 
     # Definitions and assignments
     completion = irnodes.Completion.from_lark
-    definition = irnodes.DefinitionStatement.from_lark
     assignment = irnodes.AssignmentStatement.from_lark
 
     def typed_argument(self, args):

--- a/spatialstencil/syntax/spatial_ir/lark_to_ir.py
+++ b/spatialstencil/syntax/spatial_ir/lark_to_ir.py
@@ -20,6 +20,8 @@ class TreeToSpatialIR(lark.Transformer):
     underscore = lambda self, val: str(val[0])
     true = lambda self, _: True
     false = lambda self, _: False
+    def NEWLINE(self, args):
+        return None
 
     # Literals
     @lark.v_args(inline=True)
@@ -213,7 +215,6 @@ class TreeToSpatialIR(lark.Transformer):
     call_arguments = list
     subscript_slice = list
     subgrid_expression = list
-    scope_stmt_body = list
     hops = list
     vars = list
     typed_vars = list
@@ -221,9 +222,16 @@ class TreeToSpatialIR(lark.Transformer):
     kernel_body = list
     place_body = list
     dataflow_body = list
-    compute_body = list
     phase_body = list
 
+    def compute_body(self, args):
+        if len(args) == 1 and isinstance(args[0], list):
+            return args[0]
+        return list(args)
+
+    # Statements is a special list where newlines can appear as tokens
+    def statements(self, args):
+        return [a for a in args if a is not None]
 
 # Helper functions
 

--- a/spatialstencil/syntax/spatial_ir/lark_to_ir.py
+++ b/spatialstencil/syntax/spatial_ir/lark_to_ir.py
@@ -130,11 +130,6 @@ class TreeToSpatialIR(lark.Transformer):
     # Grid/Subgrid expressions
     range_expression = irnodes.RangeExpression.from_lark
 
-    def range_and_stream(self, args):
-        rng = args[:-1]
-        stream = args[-1]
-        return rng, stream
-
     # Declarations and routing
     hop = irnodes.RoutingHop.from_lark
     routing = irnodes.RoutingDeclaration.from_lark
@@ -157,14 +152,33 @@ class TreeToSpatialIR(lark.Transformer):
     map_stmt = lambda self, args: self._scope_wrapper(irnodes.MapStatement, args)
     async_stmt = irnodes.AsyncBlock.from_lark
 
+    # Foreach statements and generators
+    receive_generator = irnodes.ReceiveGenerator.from_lark
+
     def foreach_stmt(self, args):
         completion = None
         if isinstance(args[0], irnodes.Completion) or args[0] is None:
             completion = args[0]
             args = args[1:]
 
-        iters, (rng, stream), body = args
-        return irnodes.ForeachStatement(iters, rng, stream, body, completion_name=completion)
+        iters, generators, body = args
+
+        # Semantic check: a foreach must have at least one stream generator
+        try:
+            stream_varind, stream_gen = next(
+                (i, gen) for i, gen in enumerate(generators) if isinstance(gen, irnodes.ReceiveGenerator))
+        except StopIteration:
+            raise SyntaxError('A foreach statement must have at least one stream `receive` generator')
+
+        other_gens = [gen for gen in generators if gen is not stream_gen]
+        itervars = [it for i, it in enumerate(iters) if i != stream_varind]
+        if len(other_gens) > 1:
+            raise NotImplementedError('Only one foreach zipped range is supported at the moment')
+        if not other_gens:
+            other_gens = [[]]
+
+        return irnodes.ForeachStatement(
+            itervars, other_gens[0], iters[stream_varind], stream_gen.stream_name, body, completion_name=completion)
 
     # Await for a completion object
     await_completion = irnodes.AwaitCompletionStatement.from_lark
@@ -217,6 +231,7 @@ class TreeToSpatialIR(lark.Transformer):
     call_arguments = list
     subscript_slice = list
     subgrid_expression = list
+    generators = list
     hops = list
     vars = list
     typed_vars = list

--- a/spatialstencil/syntax/spatial_ir/lark_to_ir.py
+++ b/spatialstencil/syntax/spatial_ir/lark_to_ir.py
@@ -1,12 +1,6 @@
-from dataclasses import dataclass
 import lark
 
 from spatialstencil.syntax.spatial_ir import irnodes
-
-
-@dataclass
-class ObjectType:
-    typename: str
 
 
 class TreeToSpatialIR(lark.Transformer):
@@ -20,6 +14,8 @@ class TreeToSpatialIR(lark.Transformer):
     underscore = lambda self, val: str(val[0])
     true = lambda self, _: True
     false = lambda self, _: False
+    prefix = lambda self, _: None
+
     def NEWLINE(self, args):
         return None
 
@@ -68,7 +64,6 @@ class TreeToSpatialIR(lark.Transformer):
         return irnodes.TypedIdentifier(dtype, ident.name, ident.version)
 
     float_type = int_type = uint_type = bool_type = lambda self, args: getattr(irnodes.ScalarType, str(args[0]))
-    object_type = lambda self, args: ObjectType(str(args[0]))
     stream_type = irnodes.StreamType.from_lark
 
     def array_type(self, args):
@@ -114,12 +109,19 @@ class TreeToSpatialIR(lark.Transformer):
     def ternary_op(self, args, meta=None):
         return irnodes.TernaryOperator(_expr(args[0]), _expr(args[1]), _expr(args[2]))
 
+    # Free function call to builtins
     def function_call(self, args, meta=None):
-        func, arguments = args
+        if isinstance(args[0], irnodes.Completion):
+            completion = args[0]
+            func, arguments = args[1:]
+        else:
+            completion = None
+            func, arguments = args[1:]
+
         if func == 'send':
-            return irnodes.SendStatement(*arguments)
+            return irnodes.SendStatement(*arguments, completion_name=completion)
         elif func == 'receive':
-            return irnodes.ReceiveStatement(*arguments)
+            return irnodes.ReceiveStatement(*arguments, completion_name=completion)
         raise SyntaxError(f'Unrecognized free function call to "{func}"')
 
     subscript = irnodes.ArraySlice.from_lark
@@ -141,36 +143,36 @@ class TreeToSpatialIR(lark.Transformer):
     subgrid_expression_2d = irnodes.SubgridExpression.from_lark
 
     # Scopes
-    for_stmt = irnodes.ForStatement.from_lark
-    map_stmt = irnodes.MapStatement.from_lark
+    def _scope_wrapper(self, cls, args):
+        """
+        A scope wrapper that handles `completion` assignments and `await` statements
+        """
+        completion = None
+        if isinstance(args[0], irnodes.Completion) or args[0] is None:
+            completion = args[0]
+            args = args[1:]
+        return cls(*args, completion_name=completion)
+
+    for_stmt = lambda self, args: self._scope_wrapper(irnodes.ForStatement, args)
+    map_stmt = lambda self, args: self._scope_wrapper(irnodes.MapStatement, args)
     async_stmt = irnodes.AsyncBlock.from_lark
 
     def foreach_stmt(self, args):
+        completion = None
+        if isinstance(args[0], irnodes.Completion) or args[0] is None:
+            completion = args[0]
+            args = args[1:]
+
         iters, (rng, stream), body = args
-        return irnodes.ForeachStatement(iters, stream, body, parameter_range=rng)
+        return irnodes.ForeachStatement(iters, rng, stream, body, completion_name=completion)
 
-    # Await variants
-    def await_stmt(self, args):
-        return irnodes.AwaitStatement(irnodes.Completion(args[0]))
+    # Await for a completion object
+    await_completion = irnodes.AwaitCompletionStatement.from_lark
 
-    # Definitions and assignments (combines syntax and semantics)
-    def definition(self, args):
-        dtype, identifier, rhs = args
-        if isinstance(rhs, (irnodes.MapStatement, irnodes.ForeachStatement, irnodes.SendStatement,
-                            irnodes.ReceiveStatement, irnodes.AsyncBlock)):
-            if isinstance(dtype, ObjectType) and dtype.typename == 'completion':
-                rhs.completion_name = irnodes.Completion(identifier)
-                return rhs
-            else:
-                raise SyntaxError('Only completions can be assigned to from scopes')
-        return irnodes.DefinitionStatement(dtype, identifier, rhs)
-
-    def assignment(self, args):
-        lhs, rhs = args
-        if isinstance(rhs, (irnodes.MapStatement, irnodes.ForeachStatement, irnodes.SendStatement,
-                            irnodes.ReceiveStatement, irnodes.AsyncBlock)):
-            raise SyntaxError('Cannot reassign completions to scopes')
-        return irnodes.AssignmentStatement(lhs, rhs)
+    # Definitions and assignments
+    completion = irnodes.Completion.from_lark
+    definition = irnodes.DefinitionStatement.from_lark
+    assignment = irnodes.AssignmentStatement.from_lark
 
     def typed_argument(self, args):
         if len(args) == 2:
@@ -232,6 +234,7 @@ class TreeToSpatialIR(lark.Transformer):
     # Statements is a special list where newlines can appear as tokens
     def statements(self, args):
         return [a for a in args if a is not None]
+
 
 # Helper functions
 

--- a/spatialstencil/syntax/spatial_ir/lark_to_ir.py
+++ b/spatialstencil/syntax/spatial_ir/lark_to_ir.py
@@ -1,0 +1,57 @@
+from dataclasses import dataclass
+import lark
+
+from spatialstencil.syntax.spatial_ir import irnodes
+
+
+class TreeToSpatialIR(lark.Transformer):
+    # Low-level literal syntax
+    digit = lambda self, val: int(val[0])
+    digits = lambda self, val: int(val[0])
+    hex_digit = lambda self, val: str(val[0])
+    hex_digits = lambda self, val: str(val[0])
+    letter = lambda self, val: str(val[0])
+    letters = lambda self, val: str(val[0])
+    underscore = lambda self, val: str(val[0])
+    true = lambda self, _: True
+    false = lambda self, _: False
+
+    # Literals
+    @lark.v_args(inline=True)
+    def decimal_literal(self, *digits):
+        return int(''.join(str(d) for d in digits))
+
+    @lark.v_args(inline=True)
+    def hexadecimal_literal(self, *digits):
+        return '0x' + ''.join(digits)
+
+    negated_integer_literal = lambda self, value: -value[0]
+    float_literal = lambda self, value: float(value[0])
+
+    @lark.v_args(inline=True)
+    def string_literal(self, s):
+        return irnodes.StringLiteral(s[1:-1].replace('\\"', '"'))
+
+    @lark.v_args(inline=True)
+    def bare_id(self, *elements):
+        return ''.join(str(s) for s in elements)
+
+    @lark.v_args(inline=True)
+    def suffix_id(self, *suffix):
+        return ''.join(str(s) for s in suffix)
+
+    # List types
+    statement_body = list
+    computation_body = list
+    program_body = list
+
+    # TODO: Implement
+
+
+# Helper functions
+
+
+def _expr(val: irnodes.SpatialNode | int | float | str) -> irnodes.Expression:
+    if isinstance(val, irnodes.Expression):
+        return val
+    return irnodes.Expression(val)

--- a/spatialstencil/syntax/spatial_ir/lark_to_ir.py
+++ b/spatialstencil/syntax/spatial_ir/lark_to_ir.py
@@ -1,7 +1,8 @@
 import lark
 
+from spatialstencil.syntax.common.types import ScalarType
 from spatialstencil.syntax.spatial_ir import irnodes
-from spatialstencil.syntax.spatial_ir.irnodes import StreamType
+from spatialstencil.syntax.spatial_ir.irnodes import StreamType, Identifier
 
 
 class TreeToSpatialIR(lark.Transformer):
@@ -52,10 +53,10 @@ class TreeToSpatialIR(lark.Transformer):
     def identifier(self, args):
         if len(args) == 1:
             try:
-                return irnodes.ConstantLiteral(int(args[0]), None)
+                return irnodes.ConstantLiteral(int(args[0]), ScalarType.i32)
             except ValueError:
                 try:
-                    return irnodes.ConstantLiteral(float(args[0]), None)
+                    return irnodes.ConstantLiteral(float(args[0]), ScalarType.f32)
                 except ValueError:
                     return irnodes.Identifier(args[0], 0)
         return irnodes.Identifier(*args)
@@ -139,7 +140,6 @@ class TreeToSpatialIR(lark.Transformer):
         args[0] = StreamType(args[0])
         return irnodes.RelativeStreamDeclaration(*args)
 
-
     # Scopes
     def _scope_wrapper(self, cls, args):
         """
@@ -180,6 +180,8 @@ class TreeToSpatialIR(lark.Transformer):
             raise NotImplementedError('Only one foreach zipped range is supported at the moment')
         if not other_gens:
             other_gens = [[]]
+
+        print(itervars, other_gens[0], iters[stream_varind], stream_gen, body)
 
         return irnodes.ForeachStatement(
             itervars, other_gens[0], iters[stream_varind], stream_gen, body, completion_name=completion)

--- a/spatialstencil/syntax/spatial_ir/lark_to_ir.py
+++ b/spatialstencil/syntax/spatial_ir/lark_to_ir.py
@@ -1,6 +1,7 @@
 import lark
 
 from spatialstencil.syntax.spatial_ir import irnodes
+from spatialstencil.syntax.spatial_ir.irnodes import StreamType
 
 
 class TreeToSpatialIR(lark.Transformer):
@@ -132,8 +133,12 @@ class TreeToSpatialIR(lark.Transformer):
     hop = irnodes.RoutingHop.from_lark
     routing = irnodes.RoutingDeclaration.from_lark
     field_declaration = irnodes.FieldDeclaration.from_lark
-    stream_declaration = irnodes.RelativeStreamDeclaration.from_lark
     subgrid_expression_2d = irnodes.SubgridExpression.from_lark
+
+    def stream_declaration(self, args):
+        args[0] = StreamType(args[0])
+        return irnodes.RelativeStreamDeclaration(*args)
+
 
     # Scopes
     def _scope_wrapper(self, cls, args):

--- a/spatialstencil/syntax/spatial_ir/lark_to_ir.py
+++ b/spatialstencil/syntax/spatial_ir/lark_to_ir.py
@@ -4,6 +4,11 @@ import lark
 from spatialstencil.syntax.spatial_ir import irnodes
 
 
+@dataclass
+class ObjectType:
+    typename: str
+
+
 class TreeToSpatialIR(lark.Transformer):
     # Low-level literal syntax
     digit = lambda self, val: int(val[0])
@@ -27,6 +32,7 @@ class TreeToSpatialIR(lark.Transformer):
 
     negated_integer_literal = lambda self, value: -value[0]
     float_literal = lambda self, value: float(value[0])
+    bool_literal = lambda self, value: bool(value[0])
 
     @lark.v_args(inline=True)
     def string_literal(self, s):
@@ -36,16 +42,187 @@ class TreeToSpatialIR(lark.Transformer):
     def bare_id(self, *elements):
         return ''.join(str(s) for s in elements)
 
+    def annotation(self, element):
+        return str(element[0])
+
     @lark.v_args(inline=True)
     def suffix_id(self, *suffix):
         return ''.join(str(s) for s in suffix)
 
-    # List types
-    statement_body = list
-    computation_body = list
-    program_body = list
+    # Basic types
+    def identifier(self, args):
+        if len(args) == 1:
+            try:
+                return irnodes.ConstantLiteral(int(args[0]), None)
+            except ValueError:
+                try:
+                    return irnodes.ConstantLiteral(float(args[0]), None)
+                except ValueError:
+                    return irnodes.Identifier(args[0], 0)
+        return irnodes.Identifier(*args)
 
-    # TODO: Implement
+    def typed_var(self, args):
+        dtype, ident = args
+        return irnodes.TypedIdentifier(dtype, ident.name, ident.version)
+
+    float_type = int_type = uint_type = bool_type = lambda self, args: getattr(irnodes.ScalarType, str(args[0]))
+    object_type = lambda self, args: ObjectType(str(args[0]))
+    stream_type = irnodes.StreamType.from_lark
+
+    def array_type(self, args):
+        return irnodes.ArrayType(args[0], args[1:])
+
+    def value_expr(self, args):
+        # Contract/inline value expressions that only contain another value expression
+        if len(args) == 1 and isinstance(args[0], lark.Tree) and args[0].data == 'value_expr':
+            return args[0]
+        return irnodes.Expression(*args)
+
+    # Expressions
+    def unary_op(self, args, meta=None):
+        return irnodes.UnaryOperator(str(args[0]), _expr(args[1]))
+
+    def not_test(self, args, meta=None):
+        return irnodes.UnaryOperator('not', _expr(args[0]))
+
+    def binary_op(self, args, meta=None):
+        return irnodes.BinaryOperator(_expr(args[0]), str(args[1]), _expr(args[2]))
+
+    def binary_op_logical_or(self, args, meta=None):
+        return irnodes.BinaryOperator(_expr(args[0]), 'or', _expr(args[1]))
+
+    def binary_op_or(self, args, meta=None):
+        return irnodes.BinaryOperator(_expr(args[0]), '|', _expr(args[1]))
+
+    def binary_op_logical_and(self, args, meta=None):
+        return irnodes.BinaryOperator(_expr(args[0]), 'and', _expr(args[1]))
+
+    def binary_op_and(self, args, meta=None):
+        return irnodes.BinaryOperator(_expr(args[0]), '&', _expr(args[1]))
+
+    def binary_op_xor(self, args, meta=None):
+        return irnodes.BinaryOperator(_expr(args[0]), '^', _expr(args[1]))
+
+    def binary_op_pow(self, args, meta=None):
+        return irnodes.BinaryOperator(_expr(args[0]), '**', _expr(args[1]))
+
+    def comparison(self, args, meta=None):
+        return irnodes.BinaryOperator(_expr(args[0]), str(args[1]), _expr(args[2]))
+
+    def ternary_op(self, args, meta=None):
+        return irnodes.TernaryOperator(_expr(args[0]), _expr(args[1]), _expr(args[2]))
+
+    def function_call(self, args, meta=None):
+        func, arguments = args
+        if func == 'send':
+            return irnodes.SendStatement(*arguments)
+        elif func == 'receive':
+            return irnodes.ReceiveStatement(*arguments)
+        raise SyntaxError(f'Unrecognized free function call to "{func}"')
+
+    subscript = irnodes.ArraySlice.from_lark
+    subscript_expr = irnodes.ArraySlice.from_lark
+
+    # Grid/Subgrid expressions
+    range_expression = irnodes.RangeExpression.from_lark
+
+    def range_and_stream(self, args):
+        rng = args[:-1]
+        stream = args[-1]
+        return rng, stream
+
+    # Declarations and routing
+    hop = irnodes.RoutingHop.from_lark
+    routing = irnodes.RoutingDeclaration.from_lark
+    field_declaration = irnodes.FieldDeclaration.from_lark
+    stream_declaration = irnodes.RelativeStreamDeclaration.from_lark
+    subgrid_expression_2d = irnodes.SubgridExpression.from_lark
+
+    # Scopes
+    for_stmt = irnodes.ForStatement.from_lark
+    map_stmt = irnodes.MapStatement.from_lark
+    async_stmt = irnodes.AsyncBlock.from_lark
+
+    def foreach_stmt(self, args):
+        iters, (rng, stream), body = args
+        return irnodes.ForeachStatement(iters, stream, body, parameter_range=rng)
+
+    # Await variants
+    def await_stmt(self, args):
+        return irnodes.AwaitStatement(irnodes.Completion(args[0]))
+
+    # Definitions and assignments (combines syntax and semantics)
+    def definition(self, args):
+        dtype, identifier, rhs = args
+        if isinstance(rhs, (irnodes.MapStatement, irnodes.ForeachStatement, irnodes.SendStatement,
+                            irnodes.ReceiveStatement, irnodes.AsyncBlock)):
+            if isinstance(dtype, ObjectType) and dtype.typename == 'completion':
+                rhs.completion_name = irnodes.Completion(identifier)
+                return rhs
+            else:
+                raise SyntaxError('Only completions can be assigned to from scopes')
+        return irnodes.DefinitionStatement(dtype, identifier, rhs)
+
+    def assignment(self, args):
+        lhs, rhs = args
+        if isinstance(rhs, (irnodes.MapStatement, irnodes.ForeachStatement, irnodes.SendStatement,
+                            irnodes.ReceiveStatement, irnodes.AsyncBlock)):
+            raise SyntaxError('Cannot reassign completions to scopes')
+        return irnodes.AssignmentStatement(lhs, rhs)
+
+    def typed_argument(self, args):
+        if len(args) == 2:
+            dtype, name = args
+            annotations = []
+        else:
+            dtype, annotations, name = args
+
+        return irnodes.KernelArgument(
+            dtype,
+            irnodes.Identifier(name, 0),
+            readonly='readonly' in annotations,
+            writeonly='writeonly' in annotations,
+            compiletime='compiletime' in annotations)
+
+    # Block types
+    def kernel(self, args):
+        if len(args) == 4:
+            name, parameters, arguments, body = args
+        else:
+            name = None
+            parameters, arguments, body = args
+
+        return irnodes.Kernel(name, parameters, arguments, body)
+
+    place_block = irnodes.PlaceBlock.from_lark
+    dataflow_block = irnodes.DataflowBlock.from_lark
+    compute_block = irnodes.ComputeBlock.from_lark
+
+    def phase(self, args):
+        body = args[0]
+        place = [a for a in body if isinstance(a, irnodes.PlaceBlock)]
+        dataflow = [a for a in body if isinstance(a, irnodes.DataflowBlock)]
+        compute = [a for a in body if isinstance(a, irnodes.ComputeBlock)]
+        return irnodes.Phase(place, dataflow, compute)
+
+    def parameters(self, args):
+        return [irnodes.Parameter(a) for a in args]
+
+    # List types
+    annotations = list
+    call_arguments = list
+    subscript_slice = list
+    subgrid_expression = list
+    scope_stmt_body = list
+    hops = list
+    vars = list
+    typed_vars = list
+    arguments = list
+    kernel_body = list
+    place_body = list
+    dataflow_body = list
+    compute_body = list
+    phase_body = list
 
 
 # Helper functions

--- a/spatialstencil/syntax/spatial_ir/lark_to_ir.py
+++ b/spatialstencil/syntax/spatial_ir/lark_to_ir.py
@@ -53,10 +53,10 @@ class TreeToSpatialIR(lark.Transformer):
     def identifier(self, args):
         if len(args) == 1:
             try:
-                return irnodes.ConstantLiteral(int(args[0]), ScalarType.i32)
+                return irnodes.ConstantLiteral(int(args[0]), ScalarType.UNKNOWN)
             except ValueError:
                 try:
-                    return irnodes.ConstantLiteral(float(args[0]), ScalarType.f32)
+                    return irnodes.ConstantLiteral(float(args[0]), ScalarType.UNKNOWN)
                 except ValueError:
                     return irnodes.Identifier(args[0], 0)
         return irnodes.Identifier(*args)

--- a/spatialstencil/syntax/spatial_ir/lark_to_ir.py
+++ b/spatialstencil/syntax/spatial_ir/lark_to_ir.py
@@ -163,6 +163,7 @@ class TreeToSpatialIR(lark.Transformer):
 
         iters, generators, body = args
 
+        # Split out generator from potential zipped range iterator(s)
         # Semantic check: a foreach must have at least one stream generator
         try:
             stream_varind, stream_gen = next(

--- a/spatialstencil/syntax/spatial_ir/parser.py
+++ b/spatialstencil/syntax/spatial_ir/parser.py
@@ -1,0 +1,72 @@
+import lark
+import os
+import sys
+from typing import TextIO
+
+from spatialstencil.syntax.spatial_ir import irnodes
+from spatialstencil.syntax.spatial_ir import lark_to_ir
+
+
+class Parser:
+    """
+    A spatial IR parser. Parses multiple strings faster than
+    calling ``parser.parse_string`` multiple times.
+    """
+
+    def __init__(self) -> None:
+        # Find and load the local lark file
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        larkfile = os.path.join(current_dir, 'language.lark')
+        with open(larkfile, 'r') as fp:
+            ebnf = fp.read()
+
+        # Create a parser
+        self.parser = lark.Lark(ebnf, parser='earley')
+        self.transformer = lark_to_ir.TreeToSpatialIR()
+
+    def parse(self, code: str) -> irnodes.Kernel:
+        """
+        Parses a string representing a spatial IR kernel, returning the
+        top-level kernel IR node.
+        
+        :param code: A code string in spatial stencil format.
+        :return: A Kernel node representing the root of the spatial IR.
+        """
+        tree = self.parser.parse(code)
+        ast = self.transformer.transform(tree)
+        return ast
+
+
+def parse_string(code: str) -> irnodes.Kernel:
+    """
+    Parses a string representing a spatial IR kernel, returning the
+    top-level kernel IR node.
+    
+    :param code: A code string in spatial stencil format.
+    :return: A Kernel node representing the root of the spatial IR.
+    """
+    parser = Parser()
+    return parser.parse(code)
+
+
+def parse_file(file_or_filename: TextIO | str) -> irnodes.Kernel:
+    """
+    Parses a file representing a spatial IR kernel, returning the
+    top-level kernel IR node.
+    
+    :param file_or_filename: A file path or handle to an open file to read.
+    :return: A Kernel node representing the root of the spatial IR.
+    """
+    if isinstance(file_or_filename, str):
+        with open(file_or_filename, 'r') as fp:
+            return parse_string(fp.read())
+    return parse_string(file_or_filename.read())
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print('USAGE: python -m spatialstencil.syntax.spatial_ir.parser <STENCIL FILE>')
+        exit(1)
+
+    out = parse_file(sys.argv[1])
+    print(out.as_ir())

--- a/spatialstencil/syntax/stencil_ir/irnodes.py
+++ b/spatialstencil/syntax/stencil_ir/irnodes.py
@@ -91,9 +91,8 @@ class Offset(Node):
     def add(self, other: 'Offset') -> 'Offset':
         assert all(isinstance(v, int) for v in self.values)
         assert all(isinstance(v, int) for v in other.values)
-        return Offset((self.values[0] + other.values[0],
-                       self.values[1] + other.values[1],
-                       self.values[2] + other.values[2]))
+        return Offset(
+            (self.values[0] + other.values[0], self.values[1] + other.values[1], self.values[2] + other.values[2]))
 
     def is_unknown(self) -> bool:
         return all(dim == "?" for dim in self.values)
@@ -104,7 +103,7 @@ class Offset(Node):
     def __sub__(self, other: 'Offset') -> 'Offset':
         assert all(isinstance(v, int) for v in self.values)
         assert all(isinstance(v, int) for v in other.values)
-        return Offset(tuple(self.values[i]-other.values[i] for i in range(3)))
+        return Offset(tuple(self.values[i] - other.values[i] for i in range(3)))
 
     def l1_norm(self) -> int:
         assert all(isinstance(v, int) for v in self.values)
@@ -132,9 +131,9 @@ class Offset(Node):
             if self_value != other_value:
                 return self_value < other_value
         return False
+
     def __getitem__(self, item):
         return self.values[item]
-
 
 
 @dataclass
@@ -182,6 +181,7 @@ class ViewType(Node, IRType):
     def as_ir(self, indent: int = 0) -> str:
         return f'spst.view<{self.domain.as_ir()}, {self.extent.as_ir()}, {self.dtype.as_ir()}>'
 
+
 @dataclass
 class FieldType(Node, IRType):
     domain: Domain
@@ -192,9 +192,7 @@ class FieldType(Node, IRType):
         """
         Creates an empty (not type/shape-inferred) field type.
         """
-        return FieldType(
-            domain=Cartesian(Interval(), Interval(), Interval()),
-            dtype=ScalarType.UNKNOWN)
+        return FieldType(domain=Cartesian(Interval(), Interval(), Interval()), dtype=ScalarType.UNKNOWN)
 
     def validate(self) -> None:
         assert self.dtype != ScalarType.f64
@@ -228,7 +226,6 @@ class OperationType(Node):
 
 @dataclass
 class Interval(Node, IRType):
-
     """
     Interval domain type in one dimension.
 
@@ -418,9 +415,10 @@ class Cartesian(Domain):
         assert len(tuple) == 3
         assert all(x is not None for x in tuple)
         assert not self.is_unknown()
-        return Cartesian(Interval(self.x.start + tuple[0], self.x.end + tuple[0]),
-                         Interval(self.y.start + tuple[1], self.y.end + tuple[1]),
-                         Interval(self.z.start + tuple[2], self.z.end + tuple[2]))
+        return Cartesian(
+            Interval(self.x.start + tuple[0], self.x.end + tuple[0]),
+            Interval(self.y.start + tuple[1], self.y.end + tuple[1]),
+            Interval(self.z.start + tuple[2], self.z.end + tuple[2]))
 
 
 @dataclass
@@ -780,10 +778,8 @@ class Program(Node, Operation, Block):
     computations: list[ComputationBlock | ReturnOp]
 
     def validate(self) -> None:
-        assert all((isinstance(comp, ComputationBlock) or
-                    isinstance(comp, ReturnOp) and
-                    all(isinstance(v.value, Identifier)
-                    for v in comp.values)) for comp in self.computations)
+        assert all((isinstance(comp, ComputationBlock) or isinstance(comp, ReturnOp) and all(
+            isinstance(v.value, Identifier) for v in comp.values)) for comp in self.computations)
         # Program arguments must be fields (not views)
         assert all(isinstance(i, (FieldType, ScalarType, AnyType)) for i in self.operation_type.source)
         assert all(isinstance(i, (FieldType, ScalarType, AnyType)) for i in self.operation_type.destination)
@@ -810,75 +806,15 @@ class NodeVisitor(visitor.IRNodeVisitor[Node]):
 
 
 class ScopedNodeVisitor(visitor.ScopedIRNodeVisitor[Node]):
+
     def __init__(self, *args, **kwargs):
         super().__init__(Node, *args, **kwargs)
 
+    def visit_Program(self, node: Program):
+        return self._visit_ScopeNode(node)
 
-    def visit_Program(self, program: Program):
-        """
-        Visits a program.
-
-        :param program:
-        :return:
-        """
-        self.push_scope(program)
-        self.do_visit_Program(program)
-        self.pop_scope()
-
-    def do_visit_Program(self, program: Program):
-        """
-        Called after entering the scope of the program.
-        If you want to recurse into the program, call self.generic_visit(program).
-
-        :param program:
-        :return:
-        """
-        self.generic_visit(program)
-
-    def visit_ComputationBlock(self, computation: ComputationBlock):
-        """
-        Visits a computation block.
-        Override pre_visit_ComputationBlock, do_visit_ComputationBlock, and post_visit_ComputationBlock
-        to implement the visitor.
-
-        :param computation:
-        :return:
-        """
-        self.pre_visit_ComputationBlock(computation)
-        self.push_scope(computation)
-        self.do_visit_ComputationBlock(computation)
-        self.pop_scope()
-        self.post_visit_ComputationBlock(computation)
-
-
-    def pre_visit_ComputationBlock(self, computation: ComputationBlock):
-        """
-        Called before entering the scope of the computation block.
-
-        :param computation:
-        :return:
-        """
-        pass
-
-    def do_visit_ComputationBlock(self, computation: ComputationBlock):
-        """
-        Called after entering the scope of the computation block.
-        If you want to recurse into the computation block, call self.generic_visit(computation).
-
-        :param computation:
-        :return:
-        """
-        self.generic_visit(computation)
-
-    def post_visit_ComputationBlock(self, computation: ComputationBlock):
-        """
-        Called after leaving the scope of the computation block.
-
-        :param computation:
-        :return:
-        """
-        pass
-
+    def visit_ComputationBlock(self, node: ComputationBlock):
+        return self._visit_ScopeNode(node)
 
 class NodeTransformer(visitor.IRNodeTransformer[Node]):
 

--- a/spatialstencil/syntax/stencil_ir/parser.py
+++ b/spatialstencil/syntax/stencil_ir/parser.py
@@ -20,7 +20,7 @@ class Parser:
         with open(larkfile, 'r') as fp:
             ebnf = fp.read()
 
-        # Create a parsr
+        # Create a parser
         self.parser = lark.Lark(ebnf, parser='earley')
         self.transformer = lark_to_ast.TreeToAST()
 

--- a/tests/test_lowering_gt4py_to_stencil_ir.py
+++ b/tests/test_lowering_gt4py_to_stencil_ir.py
@@ -36,7 +36,9 @@ class TestStencilIRParser(unittest.TestCase):
 
     def test_lower_gt4py_intermediates_2(self):
         program = self.gtfuncs['unused']
-        irprogram = gt4py_to_stencil_ir.lower_gt4py_to_stencil_ir(program, materialize=False)
+        with self.assertWarns(UserWarning) as wrn:
+            irprogram = gt4py_to_stencil_ir.lower_gt4py_to_stencil_ir(program, materialize=False)
+        assert 'No uses of unused' in str(wrn.warning)
         assert irprogram.name == 'unused'
         assert [inp.name for inp in irprogram.inputs] == ['inp']
         assert [out.name for out in irprogram.outputs] == ['out']

--- a/tests/test_spatial_ir_parser.py
+++ b/tests/test_spatial_ir_parser.py
@@ -2,7 +2,7 @@ from spatialstencil.syntax.spatial_ir import irnodes as spast, parser
 import os
 
 
-def test_spatial_roundtrip_hdiff():
+def test_spatial_roundtrip_laplacian():
     """
     Tests a roundtrip IR->parse->IR->parse->IR for differences.
     """
@@ -62,5 +62,5 @@ class StreamCollector(spast.NodeVisitor):
 
 
 if __name__ == '__main__':
-    test_spatial_roundtrip_hdiff()
+    test_spatial_roundtrip_laplacian()
     test_spatial_visitor()

--- a/tests/test_spatial_ir_parser.py
+++ b/tests/test_spatial_ir_parser.py
@@ -1,0 +1,47 @@
+import unittest
+from spatialstencil.syntax.spatial_ir import irnodes as spast, parser
+import os
+
+
+class TestSpatialIRParser(unittest.TestCase):
+
+    def test_roundtrip_hdiff(self):
+        """
+        Tests a roundtrip IR->parse->IR->parse->IR for differences.
+        """
+        file = os.path.join(os.path.dirname(__file__), '..', 'samples', 'spatial', 'laplacian.sptl')
+        program = parser.parse_file(file)
+        ir_1 = program.as_ir()
+        program2 = parser.parse_string(ir_1)
+        ir_2 = program2.as_ir()
+        print(ir_1)
+        assert ir_1 == ir_2
+
+    def test_visitor(self):
+        """
+        Tests the IR node visitor for the spatial IR.
+        """
+        file = os.path.join(os.path.dirname(__file__), '..', 'samples', 'spatial', 'laplacian.sptl')
+        program = parser.parse_file(file)
+
+        visitor = StreamCollector()
+        visitor.visit(program)
+        assert visitor.streams == [(1, 0), (-1, 0), (0, -1), (0, 1)]
+
+
+class StreamCollector(spast.NodeVisitor):
+    """
+    Test helper class that counts computation blocks
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.streams = []
+
+    def visit_RelativeStreamDeclaration(self, node: spast.RelativeStreamDeclaration):
+        self.streams.append((node.dx.value, node.dy.value))
+        return self.generic_visit(node)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_spatial_ir_parser.py
+++ b/tests/test_spatial_ir_parser.py
@@ -1,32 +1,29 @@
-import unittest
 from spatialstencil.syntax.spatial_ir import irnodes as spast, parser
 import os
 
 
-class TestSpatialIRParser(unittest.TestCase):
+def test_spatial_roundtrip_hdiff():
+    """
+    Tests a roundtrip IR->parse->IR->parse->IR for differences.
+    """
+    file = os.path.join(os.path.dirname(__file__), '..', 'samples', 'spatial', 'laplacian.sptl')
+    program = parser.parse_file(file)
+    ir_1 = program.as_ir()
+    program2 = parser.parse_string(ir_1)
+    ir_2 = program2.as_ir()
+    assert ir_1 == ir_2
 
-    def test_roundtrip_hdiff(self):
-        """
-        Tests a roundtrip IR->parse->IR->parse->IR for differences.
-        """
-        file = os.path.join(os.path.dirname(__file__), '..', 'samples', 'spatial', 'laplacian.sptl')
-        program = parser.parse_file(file)
-        ir_1 = program.as_ir()
-        program2 = parser.parse_string(ir_1)
-        ir_2 = program2.as_ir()
-        print(ir_1)
-        assert ir_1 == ir_2
 
-    def test_visitor(self):
-        """
-        Tests the IR node visitor for the spatial IR.
-        """
-        file = os.path.join(os.path.dirname(__file__), '..', 'samples', 'spatial', 'laplacian.sptl')
-        program = parser.parse_file(file)
+def test_spatial_visitor():
+    """
+    Tests the IR node visitor for the spatial IR.
+    """
+    file = os.path.join(os.path.dirname(__file__), '..', 'samples', 'spatial', 'laplacian.sptl')
+    program = parser.parse_file(file)
 
-        visitor = StreamCollector()
-        visitor.visit(program)
-        assert visitor.streams == [(1, 0), (-1, 0), (0, -1), (0, 1)]
+    visitor = StreamCollector()
+    visitor.visit(program)
+    assert visitor.streams == [(1, 0), (-1, 0), (0, -1), (0, 1)]
 
 
 class StreamCollector(spast.NodeVisitor):
@@ -39,9 +36,31 @@ class StreamCollector(spast.NodeVisitor):
         self.streams = []
 
     def visit_RelativeStreamDeclaration(self, node: spast.RelativeStreamDeclaration):
-        self.streams.append((node.dx.value, node.dy.value))
+        self.streams.append((self._expand_ops(node.dx.value), self._expand_ops(node.dy.value)))
         return self.generic_visit(node)
+
+    def _expand_ops(self, op: spast.UnaryOperator | spast.BinaryOperator | spast.ConstantLiteral) -> int:
+        if isinstance(op, (int, float)):
+            return op
+        if isinstance(op, spast.ConstantLiteral):
+            return op.value
+        if isinstance(op, spast.Expression):
+            return self._expand_ops(op.value)
+        if isinstance(op, spast.UnaryOperator):
+            if op.op == '+':
+                return self._expand_ops(op.value)
+            elif op.op == '-':
+                return -self._expand_ops(op.value)
+            raise TypeError(f'Unsupported unary op "{op.op}"')
+        elif isinstance(op, spast.BinaryOperator):
+            if op.op == '+':
+                return self._expand_ops(op.left) + self._expand_ops(op.right)
+            elif op.op == '-':
+                return self._expand_ops(op.left) - self._expand_ops(op.right)
+            raise TypeError(f'Unsupported binary op "{op.op}"')
+        raise TypeError(f'Unsupported node type "{type(op).__name__}"')
 
 
 if __name__ == '__main__':
-    unittest.main()
+    test_spatial_roundtrip_hdiff()
+    test_spatial_visitor()


### PR DESCRIPTION
Adds a Lark/AST parser for Spatial IR. Also makes the following modifications to the standard in order to harmonize the representation:

- [x] Blocks define completion or await, fail when neither exist
- [x] Assignment of a completion object is disallowed
- [x] Typed identifiers become part of the block
- [x] `foreach` accepts generators that are implicitly zipped together. `receive(x)` is the only built-in generator and is required
- [x] `receive(arr, stream)` is a built-in function that can be used as a shorthand for `foreach i32 i, var x in [0:N], receive(stream) { arr[i] = x; }`
- [x] Parametric place/dataflow/compute block indices also have a data type