### PR TITLE
Add benchmarking support

### DIFF
--- a/spatialstencil/cli/compiler.py
+++ b/spatialstencil/cli/compiler.py
@@ -14,8 +14,9 @@ import subprocess
 @click.option('--offset-x', '-x', default=0, type=int, help='Offset for rectangular region in x direction')
 @click.option('--offset-y', '-y', default=0, type=int, help='Offset for rectangular region in y direction')
 @click.option('--generate-only', '-g', is_flag=True, help='Only generate the output files without compiling them')
+@click.option('--disable-benchmarking', is_flag=True, help='Disable benchmarking code generation (and memory overhead)')
 def compile_spatial_ir(input_file: str, output_folder: str, param: list[str], offset_x: int, offset_y: int,
-                       generate_only: bool):
+                       generate_only: bool, disable_benchmarking: bool):
     # Parse parameters into dictionary
     kernel_parameters = {}
     for p in param:
@@ -75,7 +76,7 @@ def compile_spatial_ir(input_file: str, output_folder: str, param: list[str], of
         using_memcpy_mode = False
 
     # Lower the spatial IR to CSL
-    csl_files = s2c.lower_spatial_ir_to_csl(kernel)
+    csl_files = s2c.lower_spatial_ir_to_csl(kernel, disable_benchmarking=disable_benchmarking)
 
     # Create output folder if it doesn't exist
     os.makedirs(output_folder, exist_ok=True)

--- a/spatialstencil/lowering/spatial_ir_to_csl.py
+++ b/spatialstencil/lowering/spatial_ir_to_csl.py
@@ -173,6 +173,9 @@ const memcpy = @import_module("<memcpy/get_params>", .{{
         layout_code.write(
             f'    @export_name("{argument.identifier.name}", {dtype_as_csl(argument.dtype, export=True)}, true);\n')
 
+    # Generate benchmarking code
+    _generate_benchmarking_code_in_layout(layout_code)
+
     layout_code.write(f'''
     // Kernel
     @export_name("{kernel.name}", fn({", ".join(scalar_argument_types)})void);
@@ -284,6 +287,9 @@ task exit_task() void {{
     // On completion, unblock command stream
     sys_mod.unblock_cmd_stream();
 }}''')
+
+    # Write benchmarking code
+    _generate_benchmarking_code(header, current_code, footer)
 
     # Finalize footer
     footer.write(f'''
@@ -990,6 +996,56 @@ def _generate_task_code(rect: PEBlock, task: tdag.CSLTask, current_code: StringI
                 current_code.write(f'    @activate({task_id});\n')
             elif itedge == tdag.InterTaskEdge.UNBLOCK:
                 current_code.write(f'    @unblock({task_id});\n')
+
+
+def _generate_benchmarking_code(header: StringIO, current_code: StringIO, footer: StringIO):
+    """
+    Generates benchmarking code in the header, current code, and footer.
+    
+    :param header: A code generator stream for a file's header (where the declarations are).
+    :param current_code: The caret to the code generator at the current position (global).
+    :param footer: A code generator stream for a file's footer (the comptime block where the array would be exported).
+    """
+    # Generate tsc counters, functions, and imports in header
+    header.write("""// Benchmarking counters
+const timestamp = @import_module("<time>");
+var __benchmark_start = @zeros([3]u16);
+var __benchmark_start_ptr = &__benchmark_start;
+var __benchmark_stop = @zeros([3]u16);
+var __benchmark_stop_ptr = &__benchmark_stop;
+
+fn f_tic() void {
+    timestamp.enable_tsc();
+    timestamp.get_timestamp(&__benchmark_start);
+    sys_mod.unblock_cmd_stream();
+}
+
+fn f_toc() void {
+      timestamp.get_timestamp(&__benchmark_stop);
+      timestamp.disable_tsc();
+      sys_mod.unblock_cmd_stream();
+}""")
+
+    # Generate exports for function names and counters in footer
+    footer.write('\n    // Benchmarking exports\n')
+    footer.write('    @export_symbol(f_tic);\n')
+    footer.write('    @export_symbol(f_toc);\n')
+    footer.write('    @export_symbol(__benchmark_start_ptr, "__benchmark_start");\n')
+    footer.write('    @export_symbol(__benchmark_stop_ptr, "__benchmark_stop");\n')
+
+
+def _generate_benchmarking_code_in_layout(layout_code: StringIO):
+    """
+    Generates benchmarking code in the layout file's footer.
+
+    :param layout_code: A code generator stream for the layout code block.
+    """
+    # Generate exports for function names and counters in layout block
+    layout_code.write('\n    // Benchmarking exports\n')
+    layout_code.write('    @export_name("f_tic", fn()void);\n')
+    layout_code.write('    @export_name("f_toc", fn()void);\n')
+    layout_code.write('    @export_name("__benchmark_start", *[3]u16,  true);\n')
+    layout_code.write('    @export_name("__benchmark_stop", *[3]u16,  true);\n')
 
 
 def _collect_identifier_types(rect: PEBlock,

--- a/spatialstencil/lowering/spatial_ir_to_csl.py
+++ b/spatialstencil/lowering/spatial_ir_to_csl.py
@@ -15,12 +15,16 @@ from spatialstencil.syntax.csl.statements import name_to_csl, dtype_as_csl, expr
 UniqueDSDDict = dict[str, list[tuple[str, cslstruct.DataStructureDescriptor]]]
 
 
-def lower_spatial_ir_to_csl(kernel: spir.Kernel, rect_offset: tuple[int, int] = (0, 0)) -> list[CodeFile]:
+def lower_spatial_ir_to_csl(kernel: spir.Kernel,
+                            rect_offset: tuple[int, int] = (0, 0),
+                            disable_benchmarking: bool = False) -> list[CodeFile]:
     """
     Lowers a routed Spatial IR kernel into Cerebras CSL code.
 
     :param kernel: The Spatial IR kernel to lower.
     :param rect_offset: The offset of the output rectangle to use.
+    :param disable_benchmarking: If True, disables benchmarking code generation (and memory overhead).
+                                 Use in memory-limited scenarios.
     :return: List of code-file objects that can be written to files. See ``write_code_to_files``.
     """
     # PRECONDITION: Rectangles of dataflow/compute/place do not intersect (comes from Spatial IR)
@@ -73,7 +77,7 @@ def lower_spatial_ir_to_csl(kernel: spir.Kernel, rect_offset: tuple[int, int] = 
         # Create a unique CSL code file based on rectangle offset
         csl_name = f'code_{rect.x_range[0]}_{rect.y_range[0]}.csl'
         rect_code, color_map = generate_rectangle(kernel, rect, routing_instructions, scalar_arguments, use_memcpy_mode,
-                                                  stream_rects)
+                                                  stream_rects, disable_benchmarking)
         color_maps.append(color_map)
         csl_codes.append(CodeFile(csl_name, rect_code))
 
@@ -174,7 +178,8 @@ const memcpy = @import_module("<memcpy/get_params>", .{{
             f'    @export_name("{argument.identifier.name}", {dtype_as_csl(argument.dtype, export=True)}, true);\n')
 
     # Generate benchmarking code
-    _generate_benchmarking_code_in_layout(layout_code)
+    if not disable_benchmarking:
+        _generate_benchmarking_code_in_layout(layout_code)
 
     layout_code.write(f'''
     // Kernel
@@ -186,9 +191,13 @@ const memcpy = @import_module("<memcpy/get_params>", .{{
     return csl_codes
 
 
-def generate_rectangle(kernel: spir.Kernel, rect: Rectangle[PEBlock], routing_instructions: list[str],
-                       scalar_arguments: list[str], use_memcpy_mode: bool,
-                       stream_extents: analysis.StreamExtents) -> tuple[str, dict[str, int]]:
+def generate_rectangle(kernel: spir.Kernel,
+                       rect: Rectangle[PEBlock],
+                       routing_instructions: list[str],
+                       scalar_arguments: list[str],
+                       use_memcpy_mode: bool,
+                       stream_extents: analysis.StreamExtents,
+                       disable_benchmarking: bool = False) -> tuple[str, dict[str, int]]:
     # Code generation carets
     header = StringIO()
     current_code = StringIO()
@@ -289,7 +298,8 @@ task exit_task() void {{
 }}''')
 
     # Write benchmarking code
-    _generate_benchmarking_code(header, current_code, footer)
+    if not disable_benchmarking:
+        _generate_benchmarking_code(header, current_code, footer)
 
     # Finalize footer
     footer.write(f'''

--- a/spatialstencil/runtime/runtime.py
+++ b/spatialstencil/runtime/runtime.py
@@ -253,6 +253,10 @@ class Program:
             self.runtime.run()
             print("done.", flush=True)
 
+            if self.benchmark:
+                if self.runtime.get_id("f_tic") is None or self.runtime.get_id("f_toc") is None:
+                    raise ValueError("Benchmarking requested but not enabled in the program.")
+
             if not self.metadata.memcpy_mode and self.benchmark:
                 self.runtime.launch("f_tic", nonblock=False)
 

--- a/spatialstencil/runtime/runtime.py
+++ b/spatialstencil/runtime/runtime.py
@@ -148,6 +148,48 @@ def copy_unflatten(name: str, data: np.ndarray, shape: List[int], runtime: crt.S
     )
 
 
+def copy_back_benchmark_data(runtime: crt.SdkRuntime, metadata: ProgramMetadata) -> np.ndarray:
+    """
+    Copy back benchmarking data from the device.
+    
+    :param runtime: The Cerebras SDK runtime object to perform the copy operation
+    :param metadata: Program metadata containing input/output information
+    :return: Numpy array containing cycle counts
+    """
+    cycle_start = np.zeros(metadata.kernel_dims + [3], dtype=np.uint32)
+    cycle_stop = np.zeros(metadata.kernel_dims + [3], dtype=np.uint32)
+    cycle_counts = np.zeros(metadata.kernel_dims, dtype=np.uint64)
+    runtime.memcpy_d2h(
+        cycle_start.ravel(),
+        runtime.get_id("__benchmark_start"),
+        0,
+        0,
+        *cycle_start.shape,
+        streaming=False,
+        data_type=crt.MemcpyDataType.MEMCPY_16BIT,
+        order=crt.MemcpyOrder.ROW_MAJOR,
+        nonblock=False)
+    runtime.memcpy_d2h(
+        cycle_stop.ravel(),
+        runtime.get_id("__benchmark_stop"),
+        0,
+        0,
+        *cycle_stop.shape,
+        streaming=False,
+        data_type=crt.MemcpyDataType.MEMCPY_16BIT,
+        order=crt.MemcpyOrder.ROW_MAJOR,
+        nonblock=False)
+    # Convert 3x16-bit timestamp to the 48-bit little endian integer
+    cycle_start = (
+        cycle_start[:, :, 0].astype(np.uint64) | (cycle_start[:, :, 1].astype(np.uint64) << 16) |
+        (cycle_start[:, :, 2].astype(np.uint64) << 32))
+    cycle_stop = (
+        cycle_stop[:, :, 0].astype(np.uint64) | (cycle_stop[:, :, 1].astype(np.uint64) << 16) |
+        (cycle_stop[:, :, 2].astype(np.uint64) << 32))
+    cycle_counts = cycle_stop - cycle_start
+    return cycle_counts
+
+
 ########################################################
 # Program Class
 ########################################################
@@ -156,14 +198,16 @@ def copy_unflatten(name: str, data: np.ndarray, shape: List[int], runtime: crt.S
 class Program:
     """A program that can be run on a device."""
 
-    def __init__(self, folder: str):
+    def __init__(self, folder: str, benchmark: bool = False):
         """
         Initialize the Program with a folder containing the compiled program.
-        
+
         :param folder: Path to the folder containing the program files
+        :param benchmark: Whether to run in benchmark mode (not implemented)
         """
         self.folder = Path(folder)
         self.out_folder = self.folder / "out"
+        self.benchmark = benchmark
 
         # Load metadata
         metadata_path = self.folder / "metadata.json"
@@ -176,7 +220,7 @@ class Program:
         self.metadata = ProgramMetadata.from_json(metadata)
 
         # Initialize SDK runtime
-        self.runtime = crt.SdkRuntime(str(self.out_folder))
+        self.runtime = crt.SdkRuntime(str(self.out_folder), suppress_simfab_trace=True)
 
         # Store input/output information from metadata
         self.inputs = self.metadata.inputs
@@ -209,6 +253,9 @@ class Program:
             self.runtime.run()
             print("done.", flush=True)
 
+            if not self.metadata.memcpy_mode and self.benchmark:
+                self.runtime.launch("f_tic", nonblock=False)
+
             # Copy data to device
             for name, data in kwargs.items():
                 if name not in self.inputs:
@@ -231,7 +278,11 @@ class Program:
             # Run the program
             if self.metadata.memcpy_mode:
                 print("Launching kernel...", flush=True, end='')
+                if self.benchmark:
+                    self.runtime.launch("f_tic", nonblock=False)
                 self.runtime.launch(self.metadata.kernel_name, nonblock=False)
+                if self.benchmark:
+                    self.runtime.launch("f_toc", nonblock=False)
                 print("kernel launched.", flush=True)
 
             # Copy outputs back from device
@@ -248,7 +299,21 @@ class Program:
                 copy_unflatten(output_name, output_data, shape, self.runtime, self.metadata)
                 results[output_name] = output_data
 
-            print("Copy-back complete. Stopping runtime...", flush=True, end='')
+            if not self.metadata.memcpy_mode and self.benchmark:
+                self.runtime.launch("f_toc", nonblock=False)
+
+            print("Copy-back complete.", flush=True)
+
+            if self.benchmark:
+                cycle_counts = copy_back_benchmark_data(self.runtime, self.metadata)
+                np.save("perf_cycles.npy", cycle_counts)
+                # Print min, max, median cycle counts in a more readable format
+                print(f"Cycle count stats:\n"
+                      f"  Min:    {np.min(cycle_counts):,}\n"
+                      f"  Max:    {np.max(cycle_counts):,}\n"
+                      f"  Median: {np.median(cycle_counts).astype(np.uint64):,}")
+
+            print("Stopping runtime...", flush=True, end='')
         finally:
             self.runtime.stop()
         print("done.", flush=True)
@@ -262,11 +327,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run a compiled program with numpy array inputs")
     parser.add_argument("program_folder", help="Path to the program folder")
     parser.add_argument("input_files", nargs="+", help="Input .npy files for the program")
+    parser.add_argument("--benchmark", action="store_true", help="Run in benchmark mode")
 
     args = parser.parse_args()
 
     # Load the program
-    program = Program(args.program_folder)
+    program = Program(args.program_folder, args.benchmark)
 
     # Load input arrays from .npy files
     inputs = []


### PR DESCRIPTION
Adds cycle count benchmark handlers in the code. Benchmarking functionality is only enabled if `--benchmark` is given to the program. Otherwise, program performance is not affected (except for a ~12-byte memory overhead per PE, which can be disabled at compile-time).
