### PR TITLE
Lower arguments to external streams and fields

### DIFF
--- a/spatialstencil/cli/compiler.py
+++ b/spatialstencil/cli/compiler.py
@@ -54,7 +54,9 @@ def compile_spatial_ir(input_file: str, output_folder: str, param: list[str], of
 
     # Argument checks
     using_memcpy_mode = None
+    argnames = []
     for arg in kernel.arguments:
+        argnames.append(arg.identifier.name)
         # Change all shapes to be lists of integers
         if isinstance(arg.dtype, spa.ArrayType):
             arg.dtype.shape = [dim.eval() if isinstance(dim, spa.Expression) else int(dim) for dim in arg.dtype.shape]
@@ -136,7 +138,7 @@ def compile_spatial_ir(input_file: str, output_folder: str, param: list[str], of
         "kernel_name": kernel.name,
         "inputs": input_args,
         "outputs": output_args,
-        "argument_order": [a.identifier.name for a in kernel.arguments],
+        "argument_order": argnames,
         "memcpy_mode": using_memcpy_mode,
         "fabric_dims": [xend - xbegin, yend - ybegin],
         "kernel_dims": kernel_dims,

--- a/spatialstencil/cli/compiler.py
+++ b/spatialstencil/cli/compiler.py
@@ -119,11 +119,19 @@ def compile_spatial_ir(input_file: str, output_folder: str, param: list[str], of
     rectangles = canonicalization.consolidate_rectangles_to_equivalence_classes(kernel)
     stream_extents = analysis.detect_stream_argument_extents(rectangles, kernel)
     for argname, arg in itertools.chain(input_args.items(), output_args.items()):
-        if len(arg["shape"]) > 0: # Ignore scalar arguments
+        if len(arg["shape"]) > 0:  # Ignore scalar arguments
             arg_id = spa.Identifier(argname, 0)
             if arg_id not in stream_extents.extents:
+
+                if arg['shape'] == kernel_dims:
+                    # Special case for arguments that match the kernel grid size exactly
+                    arg["rect_offset_used"] = [0, 0]
+                    arg["column_major"] = False
+                    arg["rect_offset"] = [0, 0]
+                    continue
+
                 raise ValueError(f"Argument '{argname}' does not have a detected extent. "
-                                "Please ensure the argument is properly defined in the kernel.")
+                                 "Please ensure the argument is properly defined in the kernel.")
             arg["rect_offset_used"] = [
                 stream_extents.extents[arg_id][0].x_range[0], stream_extents.extents[arg_id][0].y_range[0]
             ]

--- a/spatialstencil/lowering/spatial_ir_to_csl.py
+++ b/spatialstencil/lowering/spatial_ir_to_csl.py
@@ -71,6 +71,9 @@ def lower_spatial_ir_to_csl(kernel: spir.Kernel,
         if e.args and isinstance(e.args[0], spir.Identifier):
             raise ValueError(f"Error in {e.args[0].lineinfo}. Undefined identifier \"{e.args[0].as_ir()}\".")
 
+    # Lower arguments to extern fields/streams
+    canonicalization.lower_arguments_to_extern(rectangles, kernel)
+
     # Collect scalar argument types
     scalar_argument_types = []
     scalar_arguments = []
@@ -291,7 +294,9 @@ const sys_mod = @import_module("<memcpy/memcpy>", memcpy_params);
     # Map task IDs to CSL task IDs
     tdag.renumber_tasks(tasks, task_creation_behavior)
 
-    print(f'Stats: Using {sum(1 if t.task_type == "local" else 0 for t in tasks)} local tasks, {sum(1 if t.task_type == "data" else 0 for t in tasks)} data tasks, {len(set(color_map.values()))} colors')
+    print(
+        f'Stats: Using {sum(1 if t.task_type == "local" else 0 for t in tasks)} local tasks, {sum(1 if t.task_type == "data" else 0 for t in tasks)} data tasks, {len(set(color_map.values()))} colors'
+    )
 
     # Generate each task
     max_task_id = csl.LOCAL_TASK_IDS[0] - 1
@@ -378,7 +383,6 @@ const sys_mod = @import_module("<memcpy/memcpy>", memcpy_params);
         if task.blocked:
             prefix = "d" if task.task_type == 'data' else ""
             current_code.write(f'    @block({prefix}task_{i}_id);\n')
-
 
     # Activate all source tasks
     non_source_tasks = set(n for i, t in enumerate(tasks) for n, _ in t.outgoing if n != i)
@@ -718,8 +722,7 @@ def _collect_unique_dsds(
     # 3. An argument that is a stream or an array of streams in non memcpy mode, or buffer_size > 1 in memcpy mode.
 
     # Collect metadata from dataflow and place blocks
-    stream_candidates: dict[str, tuple[spir.StreamDeclaration | spir.KernelArgument,
-                                       int | spir.Expression]] = {}
+    stream_candidates: dict[str, tuple[spir.StreamDeclaration | spir.KernelArgument, int | spir.Expression]] = {}
     array_candidates: dict[str, tuple[spir.FieldDeclaration, list[int | spir.Expression]]] = {}
     stream_args: set[spir.Identifier] = set()
     for df_statement in rect.dataflow.statements:

--- a/spatialstencil/lowering/spatial_ir_to_csl.py
+++ b/spatialstencil/lowering/spatial_ir_to_csl.py
@@ -709,13 +709,7 @@ def _collect_unique_dsds(
                     # Dynamic shape, must create a DSD
                     pass
 
-                # Support extern fields as streams
-                if place_statement.is_extern and len(place_statement.dtype.shape) == 1:
-                    # NOTE: I don't like this. It mimics the behavior for kernel arguments, but should not be necessary.
-                    # TODO: Try to fix
-                    stream_candidates[place_statement.field_name.as_ir()] = (place_statement, place_statement.dtype.shape[0])
-                else:
-                    array_candidates[place_statement.field_name.as_ir()] = (place_statement, place_statement.dtype.shape)
+                array_candidates[place_statement.field_name.as_ir()] = (place_statement, place_statement.dtype.shape)
 
     # Find used DSDs in compute block
     # TODO: Infer input/output queue ID based on concurrency
@@ -768,28 +762,31 @@ def _collect_unique_dsds(
                 output_queue_id_ctr += 1
                 dsds[stream_name.as_ir()].append((dsd_name, dsd))
 
-            if isinstance(stmt, spir.SendStatement) and stream_name.as_ir() in stream_candidates:
+            if isinstance(stmt, spir.SendStatement):
                 # If the send statement sends from a local array, create another DSD
+                # Do the same for the stream
                 # This case does not apply for receive statements, as they would be lowered to foreach statements
-                if stmt.local_array.as_ir() in array_candidates:
-                    _, shape = array_candidates[stmt.local_array.as_ir()]
-                    if len(shape) == 1:
-                        dsd_type = cslstruct.DSDType.mem1d
-                        extents = [str(s) if isinstance(s, int) else s.as_ir() for s in shape]
-                        indices = ['__index']
-                    else:
-                        dsd_type = cslstruct.DSDType.mem4d
-                        extents = [str(s) if isinstance(s, int) else s.as_ir() for s in shape]
-                        indices = [f'__index_{i}' for i in range(len(shape))]
+                for arr in (stmt.local_array, stmt.stream_name):
+                    if arr.as_ir() in array_candidates:
+                        _, shape = array_candidates[arr.as_ir()]
+                        if len(shape) == 1:
+                            dsd_type = cslstruct.DSDType.mem1d
+                            extents = [str(s) if isinstance(s, int) else s.as_ir() for s in shape]
+                            indices = ['__index']
+                        else:
+                            dsd_type = cslstruct.DSDType.mem4d
+                            extents = [str(s) if isinstance(s, int) else s.as_ir() for s in shape]
+                            indices = [f'__index_{i}' for i in range(len(shape))]
 
-                    dsd = cslstruct.MemoryDSD(
-                        dsd_type,
-                        name_to_csl(stmt.local_array),
-                        extents,
-                        indices,
-                        indices,
-                    )
-                    dsds[stmt.local_array.as_ir()].append((f"{name_to_csl(stmt.local_array)}_dsd", dsd))
+                        dsd = cslstruct.MemoryDSD(
+                            dsd_type,
+                            name_to_csl(arr),
+                            extents,
+                            indices,
+                            indices,
+                        )
+                        dsds[arr.as_ir()].append((f"{name_to_csl(arr)}_dsd", dsd))
+
         elif isinstance(stmt, spir.ForeachStatement):
             # If the foreach statement has a stream generator, it is a DSD
             # unless only the receive generator is given (streaming, no range provided).

--- a/spatialstencil/lowering/spatial_ir_to_csl.py
+++ b/spatialstencil/lowering/spatial_ir_to_csl.py
@@ -709,7 +709,13 @@ def _collect_unique_dsds(
                     # Dynamic shape, must create a DSD
                     pass
 
-                array_candidates[place_statement.field_name.as_ir()] = (place_statement, place_statement.dtype.shape)
+                # Support extern fields as streams
+                if place_statement.is_extern and len(place_statement.dtype.shape) == 1:
+                    # NOTE: I don't like this. It mimics the behavior for kernel arguments, but should not be necessary.
+                    # TODO: Try to fix
+                    stream_candidates[place_statement.field_name.as_ir()] = (place_statement, place_statement.dtype.shape[0])
+                else:
+                    array_candidates[place_statement.field_name.as_ir()] = (place_statement, place_statement.dtype.shape)
 
     # Find used DSDs in compute block
     # TODO: Infer input/output queue ID based on concurrency

--- a/spatialstencil/lowering/spatial_ir_to_csl.py
+++ b/spatialstencil/lowering/spatial_ir_to_csl.py
@@ -452,9 +452,9 @@ def _collect_colors_globally(kernel: spir.Kernel, rectangles: list[Rectangle[PEB
                 continue  # Unused stream
             outbound, inbound = sends_recvs[stream_decl.stream_name]
             if outbound:
-                channel_is_written.add(stream_decl.routing.channel)
+                channel_is_written.add(stream_decl.stream.routing.channel)
             if inbound:
-                channel_is_read.add(stream_decl.routing.channel)
+                channel_is_read.add(stream_decl.stream.routing.channel)
 
     # Allocate colors for each channel
     max_channel = max(channel_is_read.union(channel_is_written), default=-1)
@@ -538,21 +538,20 @@ def _allocate_colors(rect: Rectangle[PEBlock], header: StringIO, kernel: spir.Ke
     # Collect colors from streams in dataflow
     for stream_decl in rect.metadata.dataflow.statements:
         name = name_to_csl(stream_decl.stream_name)
-        cdir = 'x' if stream_decl.dx.eval() != 0 else 'y'
 
         if stream_decl.stream_name not in sends_recvs:
             continue  # Unused stream
         outbound, inbound = sends_recvs[stream_decl.stream_name]
-        if stream_decl.routing is None:
+        if stream_decl.stream.routing is None:
             raise SyntaxError(f'Non-routed stream "{name}". When generating CSL, Spatial IR code must have all streams '
                               'routed.')
-        if stream_decl.routing.channel == 'auto':
+        if stream_decl.stream.routing.channel == 'auto':
             raise SyntaxError(f'"auto" stream channel found in stream "{name}". All streams must be concretized prior '
                               'to lowering to CSL')
 
         if outbound:
             # Look up channel in color map
-            this_color = channel_to_color[channel_offset + stream_decl.routing.channel]
+            this_color = channel_to_color[channel_offset + stream_decl.stream.routing.channel]
 
             # Add to mapping
             result[name + "_OUT"] = csl.COLORS[this_color]
@@ -561,7 +560,7 @@ def _allocate_colors(rect: Rectangle[PEBlock], header: StringIO, kernel: spir.Ke
 
         if inbound:
             # Look up channel in color map
-            this_color = channel_to_color[channel_offset + stream_decl.routing.channel]
+            this_color = channel_to_color[channel_offset + stream_decl.stream.routing.channel]
 
             # Add to mapping
             result[name + "_IN"] = csl.COLORS[this_color]
@@ -678,7 +677,7 @@ def _dsd_from_array(array_candidates: dict[str, tuple[spir.FieldDeclaration, lis
     )
 
 
-def _dsd_from_stream(stream_candidates: dict[str, tuple[spir.RelativeStreamDeclaration | spir.KernelArgument,
+def _dsd_from_stream(stream_candidates: dict[str, tuple[spir.StreamDeclaration | spir.KernelArgument,
                                                         int | spir.Expression]],
                      node: spir.Identifier | spir.ArraySlice):
     ident = node if isinstance(node, spir.Identifier) else node.array
@@ -719,12 +718,12 @@ def _collect_unique_dsds(
     # 3. An argument that is a stream or an array of streams in non memcpy mode, or buffer_size > 1 in memcpy mode.
 
     # Collect metadata from dataflow and place blocks
-    stream_candidates: dict[str, tuple[spir.RelativeStreamDeclaration | spir.KernelArgument,
+    stream_candidates: dict[str, tuple[spir.StreamDeclaration | spir.KernelArgument,
                                        int | spir.Expression]] = {}
     array_candidates: dict[str, tuple[spir.FieldDeclaration, list[int | spir.Expression]]] = {}
     stream_args: set[spir.Identifier] = set()
     for df_statement in rect.dataflow.statements:
-        if isinstance(df_statement, spir.RelativeStreamDeclaration):
+        if isinstance(df_statement, spir.StreamDeclaration):
             buffer_size = df_statement.dtype.buffer_size or None
             stream_candidates[df_statement.stream_name.as_ir()] = (df_statement, buffer_size)
     for place_statement in rect.place.statements:
@@ -1024,8 +1023,9 @@ def _collect_routes(rectangles: list[Rectangle[PEBlock]], color_maps: list[dict[
             if sent:
                 color_name_outbound = f'@get_color({color_map[name_to_csl(stream.stream_name) + "_OUT"]})'
 
-            if len(stream.routing.hops) == 1:  # Inbound and outbound generated together
-                route = _route_dir(*stream.routing.hops[0].offset)
+            assert isinstance(stream.stream, spir.RelativeStreamDeclaration)
+            if len(stream.stream.routing.hops) == 1:  # Inbound and outbound generated together
+                route = _route_dir(*stream.stream.routing.hops[0].offset)
                 if sent:
                     routing_inst = INDENT + '@set_color_config(pe_x, pe_y, %s, .{ .routes = .{ .rx = .{%s}, .tx = .{%s} } });\n' % (
                         color_name_outbound, 'RAMP', route[1])
@@ -1040,7 +1040,7 @@ def _collect_routes(rectangles: list[Rectangle[PEBlock]], color_maps: list[dict[
                         routing_instructions.add(routing_inst)
             else:  # Multi-hop
                 if sent:
-                    first_hop = stream.routing.hops[0]
+                    first_hop = stream.stream.routing.hops[0]
                     route = ('RAMP', _route_dir(*first_hop.offset)[1])
                     routing_inst = INDENT + '@set_color_config(pe_x, pe_y, %s, .{ .routes = .{ .rx = .{%s}, .tx = .{%s} } });\n' % (
                         color_name_outbound, route[0], route[1])
@@ -1049,7 +1049,7 @@ def _collect_routes(rectangles: list[Rectangle[PEBlock]], color_maps: list[dict[
                         routing_instructions.add(routing_inst)
                     cur_offx = 0
                     cur_offy = 0
-                    for hop in stream.routing.hops[1:]:
+                    for hop in stream.stream.routing.hops[1:]:
                         route = _route_dir(*hop.offset)
                         cur_offx += hop.offset[0]
                         cur_offy += hop.offset[1]
@@ -1061,7 +1061,7 @@ def _collect_routes(rectangles: list[Rectangle[PEBlock]], color_maps: list[dict[
                 if received:
                     cur_offx = 0
                     cur_offy = 0
-                    last_hop = stream.routing.hops[-1]
+                    last_hop = stream.stream.routing.hops[-1]
                     route = (_route_dir(*last_hop.offset)[0], 'RAMP')
                     routing_inst = INDENT + '@set_color_config(pe_x + %d, pe_y + %d, %s, .{ .routes = .{ .rx = .{%s}, .tx = .{%s} } });\n' % (
                         cur_offx, cur_offy, color_name_inbound, route[0], route[1])
@@ -1070,7 +1070,7 @@ def _collect_routes(rectangles: list[Rectangle[PEBlock]], color_maps: list[dict[
                         routing_instructions.add(routing_inst)
                     cur_offx += last_hop.offset[0]
                     cur_offy += last_hop.offset[1]
-                    for hop in reversed(stream.routing.hops[:-1]):
+                    for hop in reversed(stream.stream.routing.hops[:-1]):
                         route = _route_dir(*hop.offset)
                         routing_inst = INDENT + '@set_color_config(pe_x + %d, pe_y + %d, %s, .{ .routes = .{ .rx = .{%s}, .tx = .{%s} } });\n' % (
                             cur_offx, cur_offy, color_name_inbound, route[0], route[1])

--- a/spatialstencil/lowering/spatial_ir_to_csl.py
+++ b/spatialstencil/lowering/spatial_ir_to_csl.py
@@ -258,7 +258,7 @@ const sys_mod = @import_module("<memcpy/memcpy>", memcpy_params);
 
     # Preprocess potential data tasks to convert to loops if possible
     if use_memcpy_mode:
-        canonicalization.convert_foreach_data_tasks_to_loops(rect, dtypes, kernel.arguments)
+        canonicalization.convert_foreach_data_tasks_to_loops(rect, dtypes)
 
     # Convert compute block subgraphs into tasks:
     #    * Make task DAG out of computations

--- a/spatialstencil/lowering/spatial_ir_to_csl.py
+++ b/spatialstencil/lowering/spatial_ir_to_csl.py
@@ -809,7 +809,8 @@ def _collect_unique_dsds(
             if not stmt.parameter_range:
                 if stream_name not in stream_args:
                     raise SyntaxError(f'Foreach generator "{stream_name.as_ir()}" without a defined '
-                                      f'range must only be used with a kernel argument.\n  In line {stmt.lineinfo}')
+                                      f'range must only be used with a kernel argument or extern_stream.'
+                                      f'\n  In line {stmt.lineinfo}')
                 # A data task will be created instead (handled in _generate_data_task)
             else:
                 if stream_name.as_ir() in stream_candidates:
@@ -862,9 +863,43 @@ def _collect_unique_dsds(
             output_queue_id_ctr += 1
             dsds[stream_name.as_ir()].append((dsd_name, dsd))
 
-        def _visit_dsd(substmt, in_foreach_or_map):
-            if isinstance(substmt, spir.SendStatement) and in_foreach_or_map:
+        def _visit_nested_receive(substmt: spir.ReceiveStatement):
+            if substmt.stream_name.as_ir() not in stream_candidates:
+                return
+            # Stream DSD (i.e., await receive in a lowered for loop)
+            stream_name = substmt.stream_name
+            dsd_type = cslstruct.DSDType.fabin
+            dsd_name = f'{name_to_csl(stream_name)}_in_dsd'
+            extents = stream_candidates[stream_name.as_ir()][1]
+            if extents is not None:  # Use buffer size
+                extents = extents if isinstance(extents, int) else extents.eval()
+            else:  # Infer from receive count
+                if isinstance(substmt.local_array, spir.TypedIdentifier):
+                    local_array = substmt.local_array.identifier
+                else:
+                    local_array = substmt.local_array
+                if isinstance(local_array, spir.ArraySlice) or isinstance(dtypes[local_array],
+                                                                         spir.ScalarType):
+                    # Scalar receive
+                    extents = 1
+                else:
+                    extents = functools.reduce(
+                        lambda a, b: a * b,
+                        [s.eval() if not isinstance(s, int) else s for s in dtypes[local_array].shape], 1)
+            fabric_color = f'{name_to_csl(stream_name)}_color'
+            nonlocal input_queue_id_ctr
+            dsd = cslstruct.FabricDSD(dsd_type, fabric_color, extents,
+                                      csl.INPUT_QUEUE_IDS[input_queue_id_ctr % len(csl.INPUT_QUEUE_IDS)])
+            input_queue_id_ctr += 1
+            dsds[stream_name.as_ir()].append((dsd_name, dsd))
+
+        def _visit_dsd(substmt, in_scope, in_assignment):
+            if isinstance(substmt, spir.SendStatement) and in_scope:
                 _visit_nested_send(substmt)
+                return
+            if isinstance(substmt, spir.ReceiveStatement):
+                if in_scope:
+                    _visit_nested_receive(substmt)
                 return
             if (isinstance(substmt, spir.Identifier) and substmt.as_ir() in array_candidates and
                     substmt.as_ir() not in dsds):
@@ -877,7 +912,7 @@ def _collect_unique_dsds(
                 return
             if substmt.array.as_ir() not in array_candidates:
                 return
-            if not in_foreach_or_map:
+            if not in_scope:
                 return
 
             dsd = _dsd_from_array(array_candidates, substmt)
@@ -921,36 +956,53 @@ class DSDVisitor(spir.NodeVisitor):
         self.toplevel = toplevel
         self.in_foreach = False
         self.in_map = False
+        self.in_for = False
+        self.in_assignment = False
         super().__init__()
 
     def visit_ForeachStatement(self, node: spir.ForeachStatement):
+        old_scope = self.in_foreach
         self.in_foreach = True
         self.generic_visit(node)
-        self.in_foreach = False
+        self.in_foreach = old_scope
 
     def visit_MapStatement(self, node: spir.MapStatement):
+        old_scope = self.in_map
         self.in_map = True
         self.generic_visit(node)
-        self.in_map = False
+        self.in_map = old_scope
+
+    def visit_ForStatement(self, node: spir.ForStatement):
+        old_scope = self.in_for
+        self.in_for = True
+        self.generic_visit(node)
+        self.in_for = old_scope
 
     def visit_Identifier(self, node: spir.Identifier):
-        self.callback(node, self.in_foreach or self.in_map)
+        self.callback(node, self.in_foreach or self.in_map, self.in_assignment)
         return
 
     def visit_SendStatement(self, node: spir.SendStatement):
-        self.callback(node, self.in_foreach or self.in_map)
+        self.callback(node, self.in_foreach or self.in_map, self.in_assignment)
+        return
+
+    def visit_ReceiveStatement(self, node: spir.ReceiveStatement):
+        self.callback(node, self.in_foreach or self.in_map, self.in_assignment)
         return
 
     def visit_ArraySlice(self, node: spir.ArraySlice):
-        self.callback(node, self.in_foreach or self.in_map)
+        self.callback(node, self.in_foreach or self.in_map, self.in_assignment)
         # Do not visit internal identifier
         return
 
     def visit_AssignmentStatement(self, node: spir.AssignmentStatement):
+        old_assignment = self.in_assignment
+        self.in_assignment = True
         if self.toplevel and isinstance(node.destination, spir.ArraySlice):
             self.generic_visit(node.source)  # Do not visit assignment to array slice
         else:
             self.generic_visit(node)
+        self.in_assignment = old_assignment
         return
 
 

--- a/spatialstencil/lowering/spatial_ir_to_csl.py
+++ b/spatialstencil/lowering/spatial_ir_to_csl.py
@@ -572,6 +572,8 @@ def _collect_and_generate_fields(place: spir.PlaceBlock, header: StringIO, foote
 
     # Add arguments to header and footer
     for field in place.statements:
+        if not field.is_extern:
+            continue
         if not isinstance(field.dtype, spir.ArrayType):  # Skip scalar arguments
             continue
         name = name_to_csl(field.field_name)

--- a/spatialstencil/lowering/spatial_ir_to_csl.py
+++ b/spatialstencil/lowering/spatial_ir_to_csl.py
@@ -427,41 +427,44 @@ def _collect_colors_globally(kernel: spir.Kernel, rectangles: list[Rectangle[PEB
     :return: Dictionary mapping each channel to its respective color.
     """
     channel_to_color: dict[int, int] = {}
-    color_offset: int = 0
-
-    # Collect colors from kernel arguments if in streaming mode
-    if not use_memcpy_mode:
-        for arg in kernel.arguments:
-            if arg.compiletime:
-                continue
-            is_input = not arg.writeonly
-            is_output = not arg.readonly
-
-            if ((isinstance(arg.dtype, spir.StreamType) and arg.dtype.buffer_size is None) or
-                (isinstance(arg.dtype, spir.ArrayType) and isinstance(arg.dtype.base_type, spir.StreamType) and
-                 arg.dtype.base_type.buffer_size is None)):
-
-                if is_input:
-                    color_offset += 1
-                if is_output:
-                    color_offset += 1
 
     # Collect, for each rectangle, which channels are being read from and written to
     channel_is_read = set()
     channel_is_written = set()
+    auto_stream_is_read = set()
+    auto_stream_is_written = set()
     for rect in rectangles:
         sends_recvs = analysis.sends_and_receives(rect.metadata.compute)
         for stream_decl in rect.metadata.dataflow.statements:
             if stream_decl.stream_name not in sends_recvs:
                 continue  # Unused stream
             outbound, inbound = sends_recvs[stream_decl.stream_name]
+            if stream_decl.stream.routing.channel == "auto":
+                if outbound:
+                    auto_stream_is_written.add(stream_decl.stream_name)
+                if inbound:
+                    auto_stream_is_read.add(stream_decl.stream_name)
+                continue  # Skip remainder of "auto" channels and assign them below
             if outbound:
                 channel_is_written.add(stream_decl.stream.routing.channel)
             if inbound:
                 channel_is_read.add(stream_decl.stream.routing.channel)
 
-    # Allocate colors for each channel
     max_channel = max(channel_is_read.union(channel_is_written), default=-1)
+
+    # Assign all "auto" channels
+    for rect in rectangles:
+        for stream_decl in rect.metadata.dataflow.statements:
+            if stream_decl.stream.routing.channel == "auto":
+                stream_decl.stream.routing.channel = max_channel + 1
+                if stream_decl.stream_name in auto_stream_is_written:
+                    channel_is_written.add(max_channel + 1)
+                if stream_decl.stream_name in auto_stream_is_read:
+                    channel_is_read.add(max_channel + 1)
+                max_channel += 1
+
+    # Allocate colors for each channel
+    color_offset = 0
     for channel in range(max_channel + 1):
         if channel in channel_to_color:
             continue
@@ -495,45 +498,7 @@ def _allocate_colors(rect: Rectangle[PEBlock], header: StringIO, kernel: spir.Ke
     :return: Dictionary mapping each stream to its respective color
     """
     result: dict[str, int] = {}
-    wrote_header: bool = False
     channel_offset: int = 0
-
-    # Collect colors from kernel arguments if in streaming mode
-    if not use_memcpy_mode:
-        input_args = []
-        output_args = []
-        for arg in kernel.arguments:
-            if arg.compiletime:
-                continue
-            if not stream_extents.is_valid(arg.identifier,
-                                           rect):  # Skip arguments that are not participating in this rectangle
-                continue
-            if arg.readonly:
-                input_args.append((False, arg))
-            elif arg.writeonly:
-                output_args.append((True, arg))
-            else:
-                input_args.append((False, arg))
-                output_args.append((True, arg))
-
-        for is_output, arg in input_args + output_args:
-            if ((isinstance(arg.dtype, spir.StreamType) and arg.dtype.buffer_size is None) or
-                (isinstance(arg.dtype, spir.ArrayType) and isinstance(arg.dtype.base_type, spir.StreamType) and
-                 arg.dtype.base_type.buffer_size is None)):
-                if not wrote_header:
-                    header.write('\n// Streaming memcpy colors\n')
-                    wrote_header = True
-
-                # If the argument is a stream, allocate a color for h2d and d2h transfers
-                name = name_to_csl(arg.identifier)
-                if not is_output:
-                    result[name + "_H2D"] = csl.COLORS[channel_offset]
-                    channel_offset += 1
-                    header.write(f'const {name}_H2D_color: color = @get_color({result[name + "_H2D"]});\n')
-                else:
-                    result[name + "_D2H"] = csl.COLORS[channel_offset]
-                    channel_offset += 1
-                    header.write(f'const {name}_D2H_color: color = @get_color({result[name + "_D2H"]});\n')
 
     if rect.metadata.dataflow.statements:
         header.write('\n// Colors\n')
@@ -729,6 +694,8 @@ def _collect_unique_dsds(
         if isinstance(df_statement, spir.StreamDeclaration):
             buffer_size = df_statement.dtype.buffer_size or None
             stream_candidates[df_statement.stream_name.as_ir()] = (df_statement, buffer_size)
+            if isinstance(df_statement.stream, spir.ExternStreamDeclaration):
+                stream_args.add(df_statement.stream_name)
     for place_statement in rect.place.statements:
         if isinstance(place_statement, spir.FieldDeclaration):
             if isinstance(place_statement.dtype, spir.ArrayType):
@@ -743,15 +710,6 @@ def _collect_unique_dsds(
                     pass
 
                 array_candidates[place_statement.field_name.as_ir()] = (place_statement, place_statement.dtype.shape)
-    for arg in kernel.arguments:
-        if isinstance(arg.dtype, spir.StreamType):
-            buffer_size = arg.dtype.buffer_size or 1
-            stream_candidates[arg.identifier.as_ir()] = (arg, buffer_size)
-            stream_args.add(arg.identifier)
-        elif isinstance(arg.dtype, spir.ArrayType) and isinstance(arg.dtype.base_type, spir.StreamType):
-            buffer_size = arg.dtype.base_type.buffer_size or 1
-            stream_candidates[arg.identifier.as_ir()] = (arg, buffer_size)
-            stream_args.add(arg.identifier)
 
     # Find used DSDs in compute block
     # TODO: Infer input/output queue ID based on concurrency
@@ -1026,7 +984,9 @@ def _collect_routes(rectangles: list[Rectangle[PEBlock]], color_maps: list[dict[
             if sent:
                 color_name_outbound = f'@get_color({color_map[name_to_csl(stream.stream_name) + "_OUT"]})'
 
-            assert isinstance(stream.stream, spir.RelativeStreamDeclaration)
+            if isinstance(stream.stream, spir.ExternStreamDeclaration):
+                continue  # Extern streams do not have on-chip routing
+
             if len(stream.stream.routing.hops) == 1:  # Inbound and outbound generated together
                 route = _route_dir(*stream.stream.routing.hops[0].offset)
                 if sent:

--- a/spatialstencil/lowering/spatial_ir_to_csl.py
+++ b/spatialstencil/lowering/spatial_ir_to_csl.py
@@ -64,9 +64,6 @@ def lower_spatial_ir_to_csl(kernel: spir.Kernel,
     try:
         canonicalization.lower_bulk_communication(rectangles)
         canonicalization.lower_array_assignment(rectangles)
-        # TODO(later): Optimize out one extra copy
-        # if use_memcpy_mode:
-        #     canonicalization.remove_memcpy_stream_operators(kernel, rectangles)
     except KeyError as e:
         if e.args and isinstance(e.args[0], spir.Identifier):
             raise ValueError(f"Error in {e.args[0].lineinfo}. Undefined identifier \"{e.args[0].as_ir()}\".")
@@ -189,17 +186,26 @@ const memcpy = @import_module("<memcpy/get_params>", .{{
         layout_code.write(rinst + '\n')
 
     # Emit symbol names for arguments and kernel
-    layout_code.write('\n    // Arguments\n')
-    for argument in kernel.arguments:
-        dtype = argument.dtype
-        if isinstance(argument.dtype, spir.ArrayType) and isinstance(argument.dtype.base_type, spir.StreamType):
-            pass
-        elif isinstance(argument.dtype, spir.StreamType):
-            # Support scalar streams
-            dtype = spir.ArrayType(argument.dtype, [1])
+    layout_code.write('\n    // Extern fields\n')
+    # Gather extern fields from kernel arguments
+    extern_fields: list[spir.FieldDeclaration] = []
+    for rect in rectangles:
+        place_block = rect.metadata.place
+        for field in place_block.statements:
+            if field.is_extern:
+                if any(field.field_name == ef.field_name for ef in extern_fields):
+                    continue
+                extern_fields.append(field)
 
-        layout_code.write(
-            f'    @export_name("{argument.identifier.name}", {dtype_as_csl(dtype, export=True)}, true);\n')
+    for field in extern_fields:
+        dtype = field.dtype
+        if isinstance(field.dtype, spir.ArrayType) and isinstance(field.dtype.base_type, spir.StreamType):
+            pass
+        elif isinstance(field.dtype, spir.StreamType):
+            # Support scalar streams
+            dtype = spir.ArrayType(field.dtype, [1])
+
+        layout_code.write(f'    @export_name("{field.field_name.name}", {dtype_as_csl(dtype, export=True)}, true);\n')
 
     # Generate benchmarking code
     if not disable_benchmarking:
@@ -557,25 +563,22 @@ def _collect_and_generate_fields(place: spir.PlaceBlock, header: StringIO, foote
         header.write(f'var {name}: {dtype_as_csl(field_dec.dtype)};\n')
 
     # Add arguments to header and footer
-    if use_memcpy_mode:
-        for argument in kernel.arguments:
-            if not isinstance(argument.dtype, spir.ArrayType):  # Skip scalar arguments
-                continue
-            name = name_to_csl(argument.identifier)
-            if isinstance(argument.dtype, spir.ArrayType) and isinstance(argument.dtype.base_type, spir.StreamType):
-                assert argument.dtype.base_type.buffer_size is not None, f'Argument {argument.identifier.name} has no buffer size defined'
-                # Ignore array size in arguments, as they are spatially mapped
-                size = argument.dtype.base_type.buffer_size.eval()
-                ptrtype = dtype_as_csl(argument.dtype, export=True)
-            else:
-                size = 1
-                ptrtype = dtype_as_csl(spir.ArrayType(argument.dtype, [1]), export=True)
+    for field in place.statements:
+        if not isinstance(field.dtype, spir.ArrayType):  # Skip scalar arguments
+            continue
+        name = name_to_csl(field.field_name)
+        if isinstance(field.dtype, spir.ArrayType):
+            # Ignore array size in arguments, as they are spatially mapped
+            ptrtype = dtype_as_csl(field.dtype, export=True)
+        else:
+            ptrtype = dtype_as_csl(spir.ArrayType(field.dtype, [1]), export=True)
 
-            header.write(f'var {name}: [{size}]'
-                         f'{dtype_as_csl(argument.dtype.element_type.element_type.element_type)};\n')
-            header.write(f'var __{name}_ptr: {ptrtype} = &{name};\n')
-            footer.write(f'    @export_symbol(__{name}_ptr, "{name}");\n')
-    else:
+        #header.write(f'var {name}: [{size}]'
+        #                f'{dtype_as_csl(field.dtype.element_type.element_type.element_type)};\n')
+        header.write(f'var __{name}_ptr: {ptrtype} = &{name};\n')
+        footer.write(f'    @export_symbol(__{name}_ptr, "{name}");\n')
+    
+    if not use_memcpy_mode:
         # TODO(later): Some scaffolding for streaming indices within rectangle code
         pass
 

--- a/spatialstencil/lowering/spatial_ir_to_csl.py
+++ b/spatialstencil/lowering/spatial_ir_to_csl.py
@@ -71,6 +71,10 @@ def lower_spatial_ir_to_csl(kernel: spir.Kernel,
     # Lower arguments to extern fields/streams
     canonicalization.lower_arguments_to_extern(rectangles, kernel)
 
+    # Add benchmarking fields
+    if not disable_benchmarking:
+        _add_benchmarking_fields(rectangles)
+
     # Collect scalar argument types
     scalar_argument_types = []
     scalar_arguments = []
@@ -207,10 +211,6 @@ const memcpy = @import_module("<memcpy/get_params>", .{{
 
         layout_code.write(f'    @export_name("{field.field_name.name}", {dtype_as_csl(dtype, export=True)}, true);\n')
 
-    # Generate benchmarking code
-    if not disable_benchmarking:
-        _generate_benchmarking_code_in_layout(layout_code)
-
     layout_code.write(f'''
     // Kernel
     @export_name("{kernel.name}", fn({", ".join(scalar_argument_types)})void);
@@ -267,7 +267,7 @@ const sys_mod = @import_module("<memcpy/memcpy>", memcpy_params);
         canonicalization.convert_foreach_data_tasks_to_loops(rect, dtypes)
 
     if not disable_benchmarking:
-        benchmark_preamble, benchmark_postamble = _generate_benchmarking_code(header, footer)
+        benchmark_preamble, benchmark_postamble = _generate_benchmarking_code(header)
     else:
         benchmark_preamble = benchmark_postamble = ''
 
@@ -587,7 +587,7 @@ def _collect_and_generate_fields(place: spir.PlaceBlock, header: StringIO, foote
         #                f'{dtype_as_csl(field.dtype.element_type.element_type.element_type)};\n')
         header.write(f'var __{name}_ptr: {ptrtype} = &{name};\n')
         footer.write(f'    @export_symbol(__{name}_ptr, "{name}");\n')
-    
+
     if not use_memcpy_mode:
         # TODO(later): Some scaffolding for streaming indices within rectangle code
         pass
@@ -878,8 +878,7 @@ def _collect_unique_dsds(
                     local_array = substmt.local_array.identifier
                 else:
                     local_array = substmt.local_array
-                if isinstance(local_array, spir.ArraySlice) or isinstance(dtypes[local_array],
-                                                                         spir.ScalarType):
+                if isinstance(local_array, spir.ArraySlice) or isinstance(dtypes[local_array], spir.ScalarType):
                     # Scalar receive
                     extents = 1
                 else:
@@ -1276,21 +1275,16 @@ def _generate_task_code(rect: PEBlock, task: tdag.CSLTask, current_code: StringI
                 current_code.write(f'    @unblock({task_id});\n')
 
 
-def _generate_benchmarking_code(header: StringIO, footer: StringIO):
+def _generate_benchmarking_code(header: StringIO):
     """
-    Generates benchmarking code in the header, current code, and footer.
+    Generates benchmarking code in the header and current code.
     
     :param header: A code generator stream for a file's header (where the declarations are).
-    :param footer: A code generator stream for a file's footer (the comptime block where the array would be exported).
     :return: A tuple of (benchmark_preamble, benchmark_postamble) strings to insert into the current code.
     """
-    # Generate tsc counters, functions, and imports in header
+    # Generate tsc imports in header
     header.write("""// Benchmarking counters
 const timestamp = @import_module("<time>");
-var __benchmark_start = @zeros([3]u16);
-var __benchmark_start_ptr = &__benchmark_start;
-var __benchmark_stop = @zeros([3]u16);
-var __benchmark_stop_ptr = &__benchmark_stop;
 """)
 
     benchmark_preamble = """    timestamp.enable_tsc();
@@ -1300,24 +1294,27 @@ var __benchmark_stop_ptr = &__benchmark_stop;
     timestamp.disable_tsc();
 """
 
-    # Generate exports for function names and counters in footer
-    footer.write('\n    // Benchmarking exports\n')
-    footer.write('    @export_symbol(__benchmark_start_ptr, "__benchmark_start");\n')
-    footer.write('    @export_symbol(__benchmark_stop_ptr, "__benchmark_stop");\n')
-
     return benchmark_preamble, benchmark_postamble
 
 
-def _generate_benchmarking_code_in_layout(layout_code: StringIO):
+def _add_benchmarking_fields(rectangles: list[Rectangle[PEBlock]]):
     """
-    Generates benchmarking code in the layout file's footer.
-
-    :param layout_code: A code generator stream for the layout code block.
+    Adds benchmarking variables to the code as extern fields.
+    :param rectangles: The rectangles to modify.
     """
-    # Generate exports for function names and counters in layout block
-    layout_code.write('\n    // Benchmarking exports\n')
-    layout_code.write('    @export_name("__benchmark_start", *[3]u16,  true);\n')
-    layout_code.write('    @export_name("__benchmark_stop", *[3]u16,  true);\n')
+    for rect in rectangles:
+        rect.metadata.place.statements.append(
+            spir.FieldDeclaration(
+                field_name=spir.Identifier('__benchmark_start', 0),
+                dtype=spir.ArrayType(spir.ScalarType.u16, [3]),
+                is_extern=True,
+            ))
+        rect.metadata.place.statements.append(
+            spir.FieldDeclaration(
+                field_name=spir.Identifier('__benchmark_stop', 0),
+                dtype=spir.ArrayType(spir.ScalarType.u16, [3]),
+                is_extern=True,
+            ))
 
 
 def _collect_identifier_types(rect: PEBlock,

--- a/spatialstencil/lowering/stencil_to_spatial_dataflow.py
+++ b/spatialstencil/lowering/stencil_to_spatial_dataflow.py
@@ -32,7 +32,7 @@ class ProgramDataflow:
     domain_collector: DomainCollector
     versioning: Versioning[spa.Identifier]
     # Maps [input_field][output_field][offset] -> stream
-    # the destination field is the first 
+    # the destination field is the first
     _stream_map: dict[sast.Identifier, dict[sast.Identifier, dict[sast.Offset, spa.Identifier]]]
 
     # stream -> x-y range where the stream sends
@@ -51,9 +51,7 @@ class ProgramDataflow:
         self.stream_send_range_map = dict()
         self.stream_receive_range_map = dict()
 
-    def get_stream(self,
-                   input_id: sast.Identifier,
-                   output_id: sast.Identifier,
+    def get_stream(self, input_id: sast.Identifier, output_id: sast.Identifier,
                    offset: sast.Offset) -> spa.Identifier | None:
         if input_id not in self._stream_map:
             return None
@@ -63,15 +61,11 @@ class ProgramDataflow:
             return None
         return self._stream_map[input_id][output_id][offset]
 
-    def _set_stream(self,
-                    input_id: sast.Identifier,
-                    output_id: sast.Identifier,
-                    offset: sast.Offset,
+    def _set_stream(self, input_id: sast.Identifier, output_id: sast.Identifier, offset: sast.Offset,
                     stream: spa.Identifier):
         self._stream_map[input_id][output_id][offset] = stream
 
-    def declare_dataflow_for_computation(self,
-                                         comp: sast.ComputationBlock) -> list[spa.DataflowBlock]:
+    def declare_dataflow_for_computation(self, comp: sast.ComputationBlock) -> list[spa.DataflowBlock]:
         """
         Generate dataflow blocks for a computation block.
         """
@@ -95,12 +89,7 @@ class ProgramDataflow:
                         stream_type = spa.StreamType(stmt.operation_type.destination[0].dtype)
                         identifier = self.versioning.next_version(f'_stream_{stmt.result.name}')
 
-                        metadata = StreamMetadata(
-                            stream_type,
-                            identifier,
-                            dx,
-                            dy
-                        )
+                        metadata = StreamMetadata(stream_type, identifier, dx, dy)
                         self._set_stream(stmt.value, stmt.result, extent, identifier)
 
                         # Generate stream
@@ -125,12 +114,7 @@ class ProgramDataflow:
                                 stream_type = spa.StreamType(access_type.dtype)
                                 identifier = self.versioning.next_version(f'_stream_{access.name}')
 
-                                metadata = StreamMetadata(
-                                    stream_type,
-                                    identifier,
-                                    dx,
-                                    dy
-                                )
+                                metadata = StreamMetadata(stream_type, identifier, dx, dy)
 
                                 self._set_stream(access, stmt.outputs[0], extent, identifier)
 
@@ -138,7 +122,7 @@ class ProgramDataflow:
                                 x_range, y_range = self.get_x_y_range(out_t, -dx, -dy)
 
                                 self.stream_send_range_map[identifier] = self.get_x_y_send_range(out_t, -dx, -dy)
-                                self.stream_receive_range_map[identifier] = self.get_x_y_receive_range(out_t,- dx, -dy)
+                                self.stream_receive_range_map[identifier] = self.get_x_y_receive_range(out_t, -dx, -dy)
 
                                 astream = AbstractStream(x_range, y_range, metadata)
                                 abstract_streams.append(astream)
@@ -146,7 +130,6 @@ class ProgramDataflow:
         blocks = self._abstract_declarations_to_block(abstract_streams)
 
         return blocks
-
 
     def _abstract_declarations_to_block(self, abstract_streams: list[AbstractStream]) -> list[spa.DataflowBlock]:
 
@@ -163,12 +146,13 @@ class ProgramDataflow:
 
             for rect in group:
 
-                stream = spa.RelativeStreamDeclaration(
+                stream = spa.StreamDeclaration(
                     dtype=rect.metadata.stream_type,
                     stream_name=rect.metadata.identifier,
-                    dx=spa.Expression(spa.ConstantLiteral(rect.metadata.dx, dtype=ScalarType.i32)),
-                    dy=spa.Expression(spa.ConstantLiteral(rect.metadata.dy, dtype=ScalarType.i32)),
-                )
+                    stream=spa.RelativeStreamDeclaration(
+                        dx=spa.Expression(spa.ConstantLiteral(rect.metadata.dx, dtype=ScalarType.i32)),
+                        dy=spa.Expression(spa.ConstantLiteral(rect.metadata.dy, dtype=ScalarType.i32)),
+                    ))
                 declarations.append(stream)
 
             var_i = self.versioning.next_version("i")
@@ -176,27 +160,25 @@ class ProgramDataflow:
 
             subgrid = spa.SubgridExpression.from_tuple(x_range, y_range)
 
-            block = spa.DataflowBlock(variables=[spa.TypedIdentifier(self.grid_var_t, var_i),
-                                                 spa.TypedIdentifier(self.grid_var_t, var_j)],
-                                      subgrid=subgrid,
-                                      statements=declarations)
+            block = spa.DataflowBlock(
+                variables=[spa.TypedIdentifier(self.grid_var_t, var_i),
+                           spa.TypedIdentifier(self.grid_var_t, var_j)],
+                subgrid=subgrid,
+                statements=declarations)
             blocks.append(block)
 
         return blocks
 
-    def get_x_y_send_range(self, out_t: sast.ViewType | sast.FieldType, dx: int, dy: int) -> tuple[tuple[int, int, int], tuple[int, int, int]]:
+    def get_x_y_send_range(self, out_t: sast.ViewType | sast.FieldType, dx: int,
+                           dy: int) -> tuple[tuple[int, int, int], tuple[int, int, int]]:
         """Defines the subgrid that sends for the given type and stream offset (dx, dy)
         """
         assert isinstance(out_t.domain, sast.Cartesian)
-        
+
         # We need a buffer of + the extent around the domain
         send_domain = out_t.domain.add((dx, dy, 0))
-        x_range = (send_domain.x[0] + self.domain_shift[0],
-                   send_domain.x[1] + self.domain_shift[0],
-                   1)
-        y_range = (send_domain.y[0] + self.domain_shift[1],
-                   send_domain.y[1] + self.domain_shift[1],
-                   1)
+        x_range = (send_domain.x[0] + self.domain_shift[0], send_domain.x[1] + self.domain_shift[0], 1)
+        y_range = (send_domain.y[0] + self.domain_shift[1], send_domain.y[1] + self.domain_shift[1], 1)
 
         assert x_range[0] >= 0, f"Type {out_t.as_ir()} at {dx}, {dy} has invalid send range"
         assert x_range[1] >= x_range[0], f"Type {out_t.as_ir()} at {dx}, {dy} has invalid send range"
@@ -204,20 +186,17 @@ class ProgramDataflow:
         assert y_range[1] >= y_range[0], f"Type {out_t.as_ir()} at {dx}, {dy} has invalid send range"
 
         return x_range, y_range
-    
-    def get_x_y_receive_range(self, out_t: sast.ViewType | sast.FieldType, dx: int, dy: int) -> tuple[tuple[int, int, int], tuple[int, int, int]]:
+
+    def get_x_y_receive_range(self, out_t: sast.ViewType | sast.FieldType, dx: int,
+                              dy: int) -> tuple[tuple[int, int, int], tuple[int, int, int]]:
         """Defines the subgrid receives for the given type and stream offset (dx, dy)
         """
         assert isinstance(out_t.domain, sast.Cartesian)
-                
+
         # We need a buffer of - the extent around the domain
         send_domain = out_t.domain
-        x_range = (send_domain.x[0] + self.domain_shift[0],
-                   send_domain.x[1] + self.domain_shift[0],
-                   1)
-        y_range = (send_domain.y[0] + self.domain_shift[1],
-                   send_domain.y[1] + self.domain_shift[1],
-                   1)
+        x_range = (send_domain.x[0] + self.domain_shift[0], send_domain.x[1] + self.domain_shift[0], 1)
+        y_range = (send_domain.y[0] + self.domain_shift[1], send_domain.y[1] + self.domain_shift[1], 1)
 
         assert x_range[0] >= 0, f"Type {out_t.as_ir()} at {dx}, {dy} has invalid receive range"
         assert x_range[1] >= x_range[0], f"Type {out_t.as_ir()} at {dx}, {dy} has invalid receive range"
@@ -226,7 +205,8 @@ class ProgramDataflow:
 
         return x_range, y_range
 
-    def get_x_y_range(self, out_t: sast.ViewType | sast.FieldType, dx: int, dy: int) -> tuple[tuple[int, int, int], tuple[int, int, int]]:
+    def get_x_y_range(self, out_t: sast.ViewType | sast.FieldType, dx: int,
+                      dy: int) -> tuple[tuple[int, int, int], tuple[int, int, int]]:
         """Defines the subgrid sends OR receives for the given type and stream offset (dx, dy)
         """
         assert isinstance(out_t.domain, sast.Cartesian)
@@ -234,12 +214,8 @@ class ProgramDataflow:
         # We need a buffer of +- the extent around the domain
         send_domain = out_t.domain.union(out_t.domain.add((dx, dy, 0)))
         #print(f"Send {send_domain}")
-        x_range = (send_domain.x[0] + self.domain_shift[0],
-                   send_domain.x[1] + self.domain_shift[0],
-                   1)
-        y_range = (send_domain.y[0] + self.domain_shift[1],
-                   send_domain.y[1] + self.domain_shift[1],
-                   1)
+        x_range = (send_domain.x[0] + self.domain_shift[0], send_domain.x[1] + self.domain_shift[0], 1)
+        y_range = (send_domain.y[0] + self.domain_shift[1], send_domain.y[1] + self.domain_shift[1], 1)
 
         assert x_range[0] >= 0, f"Type {out_t.as_ir()} at {dx}, {dy} has invalid range {x_range}"
         assert x_range[1] >= x_range[0], f"Type {out_t.as_ir()} at {dx}, {dy} has invalid range"

--- a/spatialstencil/lowering/stencil_to_spatial_routing.py
+++ b/spatialstencil/lowering/stencil_to_spatial_routing.py
@@ -1,23 +1,24 @@
-
 import copy
 from enum import Enum, auto
 from spatialstencil.lowering.versioning import Versioning
 import spatialstencil.syntax.spatial_ir.irnodes as spa
 from spatialstencil.syntax.spatial_ir.canonicalization import canonicalize_phases, inline_phases
 
+
 class ChannelStrategy(Enum):
     NONE = 0
     TRIVIAL = 1
+
 
 class KernelRouting:
     """
     Lowering Pass for generating routing assignments for a SPADA kernel
     """
     versioning: Versioning[spa.Identifier]
-    
+
     def __init__(self, versioning: Versioning[spa.Identifier]):
         self.versioning = versioning
-        
+
     def split_blocks(self, kernel: spa.Kernel) -> spa.Kernel:
         """Splits the blocks of the kernel to allow introduction of a checkerboard pattern.
         That is, for each dimension that is being communicated in, it splits all blocks into two blocks, an even and an odd block.
@@ -30,32 +31,34 @@ class KernelRouting:
         Returns:
             spa.Kernel: The split kernel, semantically equivalent.
         """
-        
+
         # Determine the active dimensions (which dimensions to split)
         # Also, assert that |dx|<= 1 and |dy|<=1, we do not support multiple hops (yet)
-        
+
         dxdy_visitor = DxDyVisitor()
         dxdy_visitor.visit(kernel)
-        
+
         if dxdy_visitor.max_dx > 1 or dxdy_visitor.max_dy > 1:
-            raise NotImplementedError("Only single hop communication is supported.")                
-        
+            raise NotImplementedError("Only single hop communication is supported.")
+
         active_dimensions = [dxdy_visitor.max_dx > 0, dxdy_visitor.max_dy > 0]
 
         # Do the split
 
         transformer = SplitTransformer(active_dimensions, self.versioning)
-        
+
         # Canonicalize: Implicitly sorts the kernel to ensure we visit compute blocks last
         kernel = canonicalize_phases(kernel)
         kernel = inline_phases(kernel)
-        
+
         # Split the kernel in preparation for coloring
         transformed_kernel = transformer.visit(kernel)
 
         return transformed_kernel
 
-    def generate_routing(self, kernel: spa.Kernel, channel_strategy: ChannelStrategy = ChannelStrategy.TRIVIAL) -> spa.Kernel:
+    def generate_routing(self,
+                         kernel: spa.Kernel,
+                         channel_strategy: ChannelStrategy = ChannelStrategy.TRIVIAL) -> spa.Kernel:
         """Generates routing blocks, possibly splitting and restructuring the kernel blocks
 
         Args:
@@ -66,11 +69,11 @@ class KernelRouting:
         """
         if channel_strategy is not ChannelStrategy.NONE:
             kernel = self.split_blocks(kernel)
-        
+
         # Gather the stream declarations
         stream_visitor = StreamVisitor()
         stream_visitor.visit(kernel)
-        
+
         # Trivial Coloring
         channel_map: dict[spa.Identifier, int] = dict()
         hops_map: dict[str, list[tuple[int, int]]] = dict()
@@ -80,18 +83,18 @@ class KernelRouting:
             for stream in stream_visitor.streams.keys():
                 channel_map[stream] = color
                 color += 1
-                
+
         for stream in stream_visitor.streams.keys():
             if stream not in hops_map:
-                hops_map[stream] = self._shortest_path_routing(stream_visitor.streams[stream].dx.eval(),
-                                                               stream_visitor.streams[stream].dy.eval())
-            
+                if isinstance(stream_visitor.streams[stream].stream, spa.RelativeStreamDeclaration):
+                    hops_map[stream] = self._shortest_path_routing(stream_visitor.streams[stream].stream.dx.eval(),
+                                                                   stream_visitor.streams[stream].stream.dy.eval())
+
         routing_trans = StreamRoutingTransformer(channel_map, hops_map)
         routing_trans.visit(kernel)
-        
+
         return kernel
-    
-    
+
     @staticmethod
     def _shortest_path_routing(dx: int, dy: int) -> list[spa.RoutingHop]:
 
@@ -116,45 +119,45 @@ class StreamRoutingTransformer(spa.NodeTransformer):
         super().__init__()
         self.channel_map = channel_map
         self.hops_map = hops_map
-        
-    def visit_RelativeStreamDeclaration(self, stmt: spa.RelativeStreamDeclaration):
-        
+
+    def visit_StreamDeclaration(self, stmt: spa.StreamDeclaration):
+
         routing = spa.RoutingDeclaration(
-            hops = copy.deepcopy(self.hops_map[stmt.stream_name]),
-            channel = self.channel_map[stmt.stream_name] if stmt.stream_name in self.channel_map else 'auto'
-        )
-        
-        stmt.routing = routing
+            hops=copy.deepcopy(self.hops_map[stmt.stream_name]),
+            channel=self.channel_map[stmt.stream_name] if stmt.stream_name in self.channel_map else 'auto')
+
+        stmt.stream.routing = routing
         return stmt
-    
+
 
 class StreamVisitor(spa.NodeVisitor):
-    
-    streams: dict[spa.Identifier, spa.RelativeStreamDeclaration]
-    
+
+    streams: dict[spa.Identifier, spa.StreamDeclaration]
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.streams = dict()
-        
-    def visit_RelativeStreamDeclaration(self, stmt: spa.RelativeStreamDeclaration):
+
+    def visit_StreamDeclaration(self, stmt: spa.StreamDeclaration):
         if stmt.stream_name not in self.streams:
             self.streams[stmt.stream_name] = stmt
 
 
 class DxDyVisitor(spa.NodeVisitor):
-    
+
     max_dx: int
     max_dy: int
-    
+
     def __init__(self):
         self.max_dx = 0
         self.max_dy = 0
         super().__init__()
-        
+
     def visit_RelativeStreamDeclaration(self, s: spa.RelativeStreamDeclaration):
         self.max_dx = max(self.max_dx, abs(s.dx.eval()))
         self.max_dy = max(self.max_dy, abs(s.dy.eval()))
-    
+
+
 class SplitTransformer(spa.NodeTransformer):
     """
     Splits the blocks of a kernel according to a checkerboard pattern.
@@ -179,10 +182,10 @@ class SplitTransformer(spa.NodeTransformer):
         5. Select: use s_even if p = σ, otherwise s_odd
     
     """
-    
+
     ## Keep track of the mapping from original stream names to their split streams (even & odd stream)
-    stream_map: dict[spa.Identifier, list[spa.RelativeStreamDeclaration]]
-    
+    stream_map: dict[spa.Identifier, list[spa.StreamDeclaration]]
+
     # Dimensions to split
     active_dimensions: list[bool]
 
@@ -190,53 +193,52 @@ class SplitTransformer(spa.NodeTransformer):
 
     _active_compute_block: spa.ComputeBlock | None
 
-    def __init__(self, active_dimensions: list[bool], versioning: Versioning[spa.Identifier], int_type: spa.ScalarType = spa.ScalarType.i16):
+    def __init__(self,
+                 active_dimensions: list[bool],
+                 versioning: Versioning[spa.Identifier],
+                 int_type: spa.ScalarType = spa.ScalarType.i16):
         super().__init__()
         self.active_dimensions = active_dimensions
         self.stream_map = dict()
         self.versioning = versioning
         self._active_compute_block = None
         self.int_type = int_type
-    
-    
+
     def _split_subgrid_x(self, subgrid: spa.SubgridExpression) -> list[spa.SubgridExpression]:
         assert self.active_dimensions[0]
-        
+
         x_step = spa.Expression(spa.ConstantLiteral(2, self.int_type))
 
         first = spa.SubgridExpression(
-            spa.RangeExpression(subgrid.x_range.start, subgrid.x_range.stop, x_step),
-            subgrid.y_range
-        )
-        
+            spa.RangeExpression(subgrid.x_range.start, subgrid.x_range.stop, x_step), subgrid.y_range)
+
         result = [first]
-        
+
         x_start = subgrid.x_range.start.value.eval() + 1
 
         if x_start < subgrid.x_range.stop.eval():
 
             second = spa.SubgridExpression(
-                spa.RangeExpression(spa.Expression(spa.ConstantLiteral(x_start, self.int_type)), subgrid.x_range.stop, x_step),
-                subgrid.y_range
-            )
-    
+                spa.RangeExpression(
+                    spa.Expression(spa.ConstantLiteral(x_start, self.int_type)), subgrid.x_range.stop, x_step),
+                subgrid.y_range)
+
             result.append(copy.deepcopy(second))
-    
+
         return result
-    
-    
+
     def _split_subgrid_y(self, subgrid: spa.SubgridExpression) -> list[spa.SubgridExpression]:
         assert self.active_dimensions[1]
-        
+
         y_step = spa.Expression(spa.ConstantLiteral(2, self.int_type))
 
         first = spa.SubgridExpression(
             subgrid.x_range,
             spa.RangeExpression(subgrid.y_range.start, subgrid.y_range.stop, y_step),
         )
-        
+
         result = [copy.deepcopy(first)]
-        
+
         y_start_2 = subgrid.y_range.start.value.eval() + 1
 
         if y_start_2 < subgrid.y_range.stop.eval():
@@ -246,12 +248,11 @@ class SplitTransformer(spa.NodeTransformer):
                 subgrid.x_range,
                 spa.RangeExpression(y_start, subgrid.y_range.stop, y_step),
             )
-            
+
             result.append(copy.deepcopy(second))
-        
+
         return result
-    
-    
+
     def _split_subgrid(self, subgrid: spa.SubgridExpression) -> list[spa.SubgridExpression]:
         """
         Splits a subgrid according to the active dimensions.
@@ -263,7 +264,7 @@ class SplitTransformer(spa.NodeTransformer):
         assert subgrid.y_range.step == None or subgrid.y_range.step.eval() == 1
         if not self.active_dimensions[0] and not self.active_dimensions[1]:
             return [subgrid]
-        
+
         grids = [subgrid]
         if self.active_dimensions[0]:
             grids = self._split_subgrid_x(subgrid)
@@ -272,11 +273,12 @@ class SplitTransformer(spa.NodeTransformer):
             for g in grids:
                 new_grids.extend(self._split_subgrid_y(g))
             grids = new_grids
-            
+
         return grids
-        
-    
-    def _split_block(self, block: spa.PlaceBlock | spa.DataflowBlock | spa.ComputeBlock) -> list[spa.PlaceBlock | spa.DataflowBlock | spa.ComputeBlock]:
+
+    def _split_block(
+        self, block: spa.PlaceBlock | spa.DataflowBlock | spa.ComputeBlock
+    ) -> list[spa.PlaceBlock | spa.DataflowBlock | spa.ComputeBlock]:
         """Splits a block according to the active dimensions (copies its contents 1:1)
 
         Args:
@@ -292,41 +294,38 @@ class SplitTransformer(spa.NodeTransformer):
             b.subgrid = g
 
         return blocks
-    
 
     def visit_PlaceBlock(self, block: spa.PlaceBlock):
         # Place blocks are merely split, no other changes
         return self._split_block(block)
-    
-    
+
     def visit_DataflowBlock(self, block: spa.DataflowBlock):
-        
+
         # The dataflow blocks get the new streams (even & odd)
         block = self.generic_visit(block)
-        
+
         # Now, we actually do the split
         blocks = self._split_block(block)
         return blocks
 
-    
-    def visit_RelativeStreamDeclaration(self, stmt: spa.RelativeStreamDeclaration):
-        
-        active_x = abs(stmt.dx.eval())
-        active_y = abs(stmt.dy.eval())
+    def visit_StreamDeclaration(self, stmt: spa.StreamDeclaration):
+        assert isinstance(stmt.stream, spa.RelativeStreamDeclaration)
+        active_x = abs(stmt.stream.dx.eval())
+        active_y = abs(stmt.stream.dy.eval())
         if active_x + active_y > 1:
             raise NotImplementedError("Currently, only 1-hop communication is supported")
-        
+
         if active_y:
             assert self.active_dimensions[1]
         if active_x:
             assert self.active_dimensions[0]
-            
+
         assert active_x + active_y > 0
-        
+
         if stmt.stream_name in self.stream_map:
-            
+
             return copy.deepcopy(self.stream_map[stmt.stream_name])
-        
+
         else:
             # New stream names
             even = self.versioning.next_version(stmt.stream_name.name)
@@ -337,54 +336,53 @@ class SplitTransformer(spa.NodeTransformer):
             stmt_2 = copy.deepcopy(stmt)
             stmt_1.stream_name = even
             stmt_2.stream_name = odd
-            
+
             self.stream_map[stmt.stream_name] = [stmt_1, stmt_2]
-            
+
             return [stmt_1, stmt_2]
-        
-    
-    def visit_ComputeBlock(self, block: spa.ComputeBlock): 
+
+    def visit_ComputeBlock(self, block: spa.ComputeBlock):
         # The compute blocks need adjustment, use the even / odd stream depending on the parity of the block and the sign of the communication
-        
+
         # First, split:
         split_blocks = self._split_block(block)
         result = []
-        
+
         for b in split_blocks:
             self._active_compute_block = b
-            
+
             result.append(self.generic_visit(b))
-            
+
             self._active_compute_block = None
-        
+
         return result
-    
-    
+
     def visit_SendStatement(self, stmt: spa.SendStatement):
         stmt.stream_name = self._resolve_communication_stream(stmt.stream_name, is_receive=False)
         return stmt
-    
-    
+
     def visit_ReceiveStatement(self, stmt: spa.ReceiveStatement):
         stmt.stream_name = self._resolve_communication_stream(stmt.stream_name, is_receive=True)
         return stmt
-    
+
     def visit_ReceiveGenerator(self, gen: spa.ReceiveGenerator):
         gen.stream_name = self._resolve_communication_stream(gen.stream_name, is_receive=True)
         return gen
-        
+
     def _resolve_communication_stream(self, stream_name: spa.Identifier, is_receive: bool):
         if not isinstance(stream_name, spa.Identifier):
             # Arguments - do not change
             return stream_name
         
         streams = self.stream_map[stream_name]
-        
-        dx = streams[0].dx.value.eval()
-        dy = streams[0].dy.value.eval()
-        
+        if not isinstance(streams[0].stream, spa.RelativeStreamDeclaration):
+            return stream_name  # Non-relative streams are not changed
+
+        dx = streams[0].stream.dx.value.eval()
+        dy = streams[0].stream.dy.value.eval()
+
         assert abs(dx) + abs(dy) <= 1
-        
+
         if abs(dx) > 0:
             sign = dx > 0
             block_parity: int = self._active_compute_block.subgrid.x_range.start.value.eval() % 2
@@ -394,11 +392,11 @@ class SplitTransformer(spa.NodeTransformer):
             block_parity: int = self._active_compute_block.subgrid.y_range.start.value.eval() % 2
 
         assert isinstance(block_parity, int)
-        
+
         # Logically flip the direction of stream when receiving
         if is_receive:
             sign = not sign
-            
+
         channel_idx = block_parity if sign else (block_parity + 1) % 2
-        
+
         return streams[channel_idx].stream_name

--- a/spatialstencil/syntax/common/basenode.py
+++ b/spatialstencil/syntax/common/basenode.py
@@ -95,6 +95,8 @@ class BaseNode:
             elif isinstance(field_type, type) and issubclass(field_type, BaseNode):
                 # Traverse if it’s a BaseNode subclass
                 field_type.validate_schema(visited)
+            elif origin is typing.Literal:
+                continue
             elif origin and issubclass(origin, (tuple, list)):  # Sequence
                 # Check contents of sequences
                 _check_sequence(field_type, field_name)

--- a/spatialstencil/syntax/csl/statements.py
+++ b/spatialstencil/syntax/csl/statements.py
@@ -109,13 +109,9 @@ def emit_copy(source: spir.Identifier | spir.ArraySlice,
                 dtype = identifier.dtype
             else:
                 dtype = dtypes.get(identifier)
-            if isinstance(dtype, spir.ArrayType):
-                dims_to_ignore = len(dtype.shape)
-            else:
-                dims_to_ignore = 0
             if isinstance(value, spir.ArraySlice):
                 indices: list[str] = []
-                for idx in value.indices[dims_to_ignore:]:
+                for idx in value.indices:
                     if isinstance(idx, spir.Expression):
                         indices.append(emit_expression(idx, dsds, dtypes))
                     elif isinstance(idx, spir.RangeExpression):

--- a/spatialstencil/syntax/spatial_ir/canonicalization.py
+++ b/spatialstencil/syntax/spatial_ir/canonicalization.py
@@ -334,63 +334,11 @@ def lower_array_assignment(rectangles: list[Rectangle[PEBlock]]) -> None:
         rect.metadata.compute = _ArrayAssignmentLowerer(rect.metadata.place).visit(rect.metadata.compute)
 
 
-class _MemCpyStreamOperatorRemover(spir.NodeTransformer):
-
-    def __init__(self, stream_args: set[spir.Identifier]):
-        super().__init__()
-        self.stream_args = stream_args
-
-    def visit_ReceiveStatement(self, node: spir.ReceiveStatement):
-        if isinstance(node.stream_name, spir.Identifier) and node.stream_name in self.stream_args:
-            return None
-        if isinstance(node.stream_name, spir.ArraySlice) and node.stream_name.array in self.stream_args:
-            return None
-        return self.generic_visit(node)
-
-    def visit_SendStatement(self, node: spir.SendStatement):
-        if isinstance(node.stream_name, spir.Identifier) and node.stream_name in self.stream_args:
-            return None
-        if isinstance(node.stream_name, spir.ArraySlice) and node.stream_name.array in self.stream_args:
-            return None
-        return self.generic_visit(node)
-
-    def visit_ForeachStatement(self, node: spir.ForeachStatement):
-        if isinstance(node.receive_stream.stream_name,
-                      spir.Identifier) and node.receive_stream.stream_name in self.stream_args:
-            return None
-        if isinstance(node.receive_stream.stream_name,
-                      spir.ArraySlice) and node.receive_stream.stream_name.array in self.stream_args:
-            return None
-        return self.generic_visit(node)
-
-
-def remove_memcpy_stream_operators(kernel: spir.Kernel, rectangles: list[Rectangle[PEBlock]]) -> None:
-    """
-    Removes receives/sends/foreach loops that involve kernel arguments from the given rectangles in memcpy mode.
-    This pass is performed because memcpy mode will already copy the memory in and out outside the kernel code.
-
-    :param kernel: The kernel to modify.
-    :param rectangles: A list of PE block rectangles to modify.
-    """
-    stream_args: set[spir.Identifier] = set()
-    for arg in kernel.arguments:
-        if isinstance(arg.dtype, spir.StreamType):
-            stream_args.add(arg.identifier)
-        elif isinstance(arg.dtype, spir.ArrayType) and isinstance(arg.dtype.base_type, spir.StreamType):
-            stream_args.add(arg.identifier)
-
-    # TODO(later): Verify that each stream argument is used once, and then replace every occurrence of the stream
-    #              argument with its internal name.
-    for rect in rectangles:
-        rect.metadata.compute = _MemCpyStreamOperatorRemover(stream_args).visit(rect.metadata.compute)
-
-
 class _ForeachDataTaskToLoopConverter(spir.NodeTransformer):
 
-    def __init__(self, dtypes: dict[spir.Identifier, spir.IRType], kernel_arguments: list[spir.KernelArgument]):
+    def __init__(self, dtypes: dict[spir.Identifier, spir.IRType]):
         super().__init__()
         self.dtypes = dtypes
-        self.kernel_arguments = set(k.identifier for k in kernel_arguments)
 
     def visit_ForeachStatement(self, node: spir.ForeachStatement):
         from spatialstencil.syntax.csl import dsd_ops
@@ -439,17 +387,15 @@ class _ForeachDataTaskToLoopConverter(spir.NodeTransformer):
         return loop_statement
 
 
-def convert_foreach_data_tasks_to_loops(rect: Rectangle[PEBlock], dtypes: dict[spir.Identifier, spir.IRType],
-                                        kernel_arguments: list[spir.KernelArgument]) -> None:
+def convert_foreach_data_tasks_to_loops(rect: Rectangle[PEBlock], dtypes: dict[spir.Identifier, spir.IRType]) -> None:
     """
     Converts foreach blocks on input arguments to (async) loop blocks in memcpy mode.
     This pass is performed because memcpy mode will already copy the memory in and out outside the kernel code.
 
     :param rect: A single PE block rectangle to modify.
     :param dtypes: A mapping of identifier to its type in the given rectangle.
-    :param kernel_arguments: The list of kernel arguments, used to determine which identifiers are arguments.
     """
-    rect.metadata.compute = _ForeachDataTaskToLoopConverter(dtypes, kernel_arguments).visit(rect.metadata.compute)
+    rect.metadata.compute = _ForeachDataTaskToLoopConverter(dtypes).visit(rect.metadata.compute)
 
 
 def lower_arguments_to_extern(rectangles: list[Rectangle[PEBlock]], kernel: spir.Kernel) -> None:

--- a/spatialstencil/syntax/spatial_ir/canonicalization.py
+++ b/spatialstencil/syntax/spatial_ir/canonicalization.py
@@ -403,9 +403,8 @@ def convert_foreach_data_tasks_to_loops(rect: Rectangle[PEBlock], dtypes: dict[s
 
 def lower_arguments_to_extern(rectangles: list[Rectangle[PEBlock]], kernel: spir.Kernel) -> None:
     """
-    Lowers stream arguments to extern stream declarations in a dataflow or place block.
-    Keeps kernel arguments for stream extent computation.
-    Scalar arguments are unaffected.
+    Lowers stream arguments to extern field declarations in a place block or 
+    extern stream declarations in a dataflow block. Scalar arguments are unaffected.
 
     :param rectangles: A list of PE block rectangles to modify.
     :param kernel: The kernel whose arguments are being lowered.

--- a/spatialstencil/syntax/spatial_ir/canonicalization.py
+++ b/spatialstencil/syntax/spatial_ir/canonicalization.py
@@ -457,10 +457,12 @@ def lower_arguments_to_extern(rectangles: list[Rectangle[PEBlock]], kernel: spir
     # Insert dataflow and place blocks for every compute block
     # (unused fields/streams will be pruned later)
     for rect in rectangles:
-        if stream_decls:
-            rect.metadata.dataflow.statements.extend(copy.deepcopy(stream_decls))
-        if field_decls:
-            rect.metadata.place.statements.extend(copy.deepcopy(field_decls))
+        for decl in stream_decls:
+            if decl not in rect.metadata.dataflow.statements:
+                rect.metadata.dataflow.statements.append(copy.deepcopy(decl))
+        for decl in field_decls:
+            if decl not in rect.metadata.place.statements:
+                rect.metadata.place.statements.append(copy.deepcopy(decl))
 
         for stmt in rect.metadata.compute.statements:
             stmt = replacer.visit(stmt)

--- a/spatialstencil/syntax/spatial_ir/canonicalization.py
+++ b/spatialstencil/syntax/spatial_ir/canonicalization.py
@@ -345,11 +345,14 @@ class _ForeachDataTaskToLoopConverter(spir.NodeTransformer):
         if dsd_ops.get_dsd_op(self.dtypes, node) is not None:
             return self.generic_visit(node)
 
+        if isinstance(self.dtypes[node.receive_stream.stream_name], spir.StreamType):
+            return self.generic_visit(node)
+
         body_statements = [self.visit(stmt) for stmt in node.body]
         loop_variables = [copy.deepcopy(var) for var in node.variables]
         loop_ranges = [copy.deepcopy(rng) for rng in node.parameter_range]
         stream_target = copy.deepcopy(node.receive_stream.stream_name)
-        if loop_ranges:
+        if isinstance(self.dtypes[stream_target], spir.ArrayType) and loop_ranges:
             index_exprs = []
             for var in loop_variables:
                 idx_identifier = copy.deepcopy(var.identifier)

--- a/spatialstencil/syntax/spatial_ir/canonicalization.py
+++ b/spatialstencil/syntax/spatial_ir/canonicalization.py
@@ -137,13 +137,20 @@ def consolidate_rectangles_to_equivalence_classes(kernel: spir.Kernel) -> list[R
         rect = block.get_grid_rect()
         rect_to_stride[rect] = block.get_grid_stride()
         if isinstance(block, spir.PlaceBlock):
-            assert result[rect].place is None
-            result[rect].place = block
+            if result[rect].place is not None:
+                result[rect].place.statements.extend(block.statements)
+                block.statements.clear()
+            else:
+                result[rect].place = block
         elif isinstance(block, spir.DataflowBlock):
-            assert result[rect].dataflow is None
-            result[rect].dataflow = block
+            if result[rect].dataflow is not None:
+                result[rect].dataflow.statements.extend(block.statements)
+                block.statements.clear()
+            else:
+                result[rect].dataflow = block
         elif isinstance(block, spir.ComputeBlock):
-            assert result[rect].compute is None
+            if result[rect].compute is not None:
+                raise ValueError('Multiple compute blocks found for the same rectangle after inlining phases.')
             result[rect].compute = block
 
     # Fill in remainder of PEBlock with empty scopes (e.g., blocks without dataflow)
@@ -445,3 +452,71 @@ def convert_foreach_data_tasks_to_loops(rect: Rectangle[PEBlock], dtypes: dict[s
     :param kernel_arguments: The list of kernel arguments, used to determine which identifiers are arguments.
     """
     rect.metadata.compute = _ForeachDataTaskToLoopConverter(dtypes, kernel_arguments).visit(rect.metadata.compute)
+
+
+def lower_arguments_to_extern(rectangles: list[Rectangle[PEBlock]], kernel: spir.Kernel) -> None:
+    """
+    Lowers stream arguments to extern stream declarations in a dataflow or place block.
+    Keeps kernel arguments for stream extent computation.
+    Scalar arguments are unaffected.
+
+    :param rectangles: A list of PE block rectangles to modify.
+    :param kernel: The kernel whose arguments are being lowered.
+    :note: Modifies the kernel in-place.
+    """
+    # Create dataflow or place block depending on argument types
+    stream_decls: list[spir.StreamDeclaration] = []
+    field_decls: list[spir.FieldDeclaration] = []
+
+    # Create declarations
+    for arg in kernel.arguments:
+        dtype = arg.dtype
+        if isinstance(dtype, spir.ArrayType):
+            dtype = dtype.base_type
+
+        if isinstance(dtype, spir.StreamType):
+            if dtype.buffer_size is not None:
+                field_decls.append(
+                    spir.FieldDeclaration(
+                        dtype=spir.ArrayType(dtype.element_type, [dtype.buffer_size]),
+                        field_name=arg.identifier,
+                        is_extern=True))
+            else:
+                if arg.readonly or (not arg.readonly and not arg.writeonly):
+                    extern_decl = spir.StreamDeclaration(
+                        stream_name=arg.identifier,
+                        dtype=dtype,
+                        stream=spir.ExternStreamDeclaration('in', routing=spir.RoutingDeclaration()))
+                    stream_decls.append(extern_decl)
+                if arg.writeonly or (not arg.readonly and not arg.writeonly):
+                    extern_decl = spir.StreamDeclaration(
+                        stream_name=arg.identifier,
+                        dtype=dtype,
+                        stream=spir.ExternStreamDeclaration('out', routing=spir.RoutingDeclaration()))
+                    stream_decls.append(extern_decl)
+
+    # Replace all index expressions of our newly created extern streams/fields
+    extern_names = set(decl.stream_name for decl in stream_decls) | set(decl.field_name for decl in field_decls)
+
+    class _ArgumentReplacer(spir.NodeTransformer):
+
+        def visit_ArraySlice(self, node: spir.ArraySlice):
+            if node.array in extern_names:
+                return node.array
+            return self.generic_visit(node)
+
+    replacer = _ArgumentReplacer()
+
+    # Insert dataflow and place blocks for every compute block
+    # (unused fields/streams will be pruned later)
+    for rect in rectangles:
+        if stream_decls:
+            rect.metadata.dataflow.statements.extend(copy.deepcopy(stream_decls))
+        if field_decls:
+            rect.metadata.place.statements.extend(copy.deepcopy(field_decls))
+
+        for stmt in rect.metadata.compute.statements:
+            stmt = replacer.visit(stmt)
+
+    # Remove arguments from kernel
+    kernel.arguments = [arg for arg in kernel.arguments if arg.identifier not in extern_names]

--- a/spatialstencil/syntax/spatial_ir/canonicalization.py
+++ b/spatialstencil/syntax/spatial_ir/canonicalization.py
@@ -394,8 +394,6 @@ class _ForeachDataTaskToLoopConverter(spir.NodeTransformer):
 
     def visit_ForeachStatement(self, node: spir.ForeachStatement):
         from spatialstencil.syntax.csl import dsd_ops
-        if dsd_ops._get_id(node.receive_stream.stream_name) not in self.kernel_arguments:
-            return self.generic_visit(node)
         if dsd_ops.get_dsd_op(self.dtypes, node) is not None:
             return self.generic_visit(node)
 

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -321,7 +321,7 @@ class ArraySlice(SpatialNode):
         assert isinstance(self.array, Identifier)
         assert isinstance(self.indices, list)
         assert all(isinstance(idx, (Expression, RangeExpression)) for idx in self.indices)
- 
+
     def as_ir(self, indent: int = 0) -> str:
         index_strs = []
         for idx in self.indices:
@@ -483,6 +483,7 @@ class FieldDeclaration(SpatialNode):
     """
     dtype: Union[ScalarType, ArrayType]
     field_name: Identifier
+    is_extern: bool = False
 
     def validate(self) -> None:
         assert isinstance(self.dtype, (ScalarType, ArrayType))
@@ -490,7 +491,8 @@ class FieldDeclaration(SpatialNode):
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
-        return f'{indent_str}{self.dtype.as_ir()} {self.field_name.as_ir()}'
+        prefix = "extern " if self.is_extern else ""
+        return f'{indent_str}{prefix}{self.dtype.as_ir()} {self.field_name.as_ir()}'
 
 
 ###
@@ -574,15 +576,11 @@ class RelativeStreamDeclaration(SpatialNode):
     A stream declaration inside a dataflow block that declares a communication stream
     to and from PEs at relative positions, with an optional routing declaration.
     """
-    dtype: StreamType
-    stream_name: Identifier
     dx: Expression
     dy: Expression
     routing: Optional[RoutingDeclaration] = None
 
     def validate(self) -> None:
-        assert isinstance(self.dtype, StreamType)
-        assert isinstance(self.stream_name, Identifier)
         assert isinstance(self.dx, Expression)
         assert isinstance(self.dy, Expression)
         if self.routing:
@@ -593,8 +591,50 @@ class RelativeStreamDeclaration(SpatialNode):
         routing_str = ""
         if self.routing:
             routing_str = f" {{\n{self.routing.as_ir(indent + 1)}\n{indent_str}}}"
-        return (f'{indent_str}stream<{self.dtype.element_type.as_ir()}> {self.stream_name.as_ir()} = '
-                f'relative_stream({self.dx.as_ir()}, {self.dy.as_ir()}){routing_str}')
+        return (f'relative_stream({self.dx.as_ir()}, {self.dy.as_ir()}){routing_str}')
+
+
+@dataclass
+class ExternStreamDeclaration(SpatialNode):
+    """
+    A stream declaration inside a dataflow block that declares a communication stream
+    to and from PEs and the host, with an optional channel declaration.
+    """
+    direction: Literal["in", "out"]
+    routing: Optional[RoutingDeclaration] = None
+
+    def validate(self) -> None:
+        assert self.direction in ["in", "out"]
+        if self.routing:
+            assert isinstance(self.routing, RoutingDeclaration)
+            assert self.routing.hops == "auto", "Extern streams can only have 'auto' hops."
+
+    def as_ir(self, indent: int = 0) -> str:
+        indent_str = '  ' * indent
+        routing_str = ""
+        if self.routing:
+            routing_str = f" {{\n{self.routing.as_ir(indent + 1)}\n{indent_str}}}"
+        return (f'extern_stream({self.direction}){routing_str}')
+
+
+@dataclass
+class StreamDeclaration(SpatialNode):
+    """
+    A stream declaration inside a dataflow block that declares a communication stream
+    to and from PEs at relative positions, with an optional routing declaration.
+    """
+    dtype: StreamType
+    stream_name: Identifier
+    stream: RelativeStreamDeclaration | ExternStreamDeclaration
+
+    def validate(self) -> None:
+        assert isinstance(self.dtype, StreamType)
+        assert isinstance(self.stream_name, Identifier)
+        assert isinstance(self.stream, (RelativeStreamDeclaration, ExternStreamDeclaration))
+
+    def as_ir(self, indent: int = 0) -> str:
+        indent_str = '  ' * indent
+        return f'{indent_str}stream<{self.dtype.element_type.as_ir()}> {self.stream_name.as_ir()} = {self.stream.as_ir()}'
 
 
 ###
@@ -609,11 +649,11 @@ class DataflowBlock(SpatialNode):
     """
     variables: list[TypedIdentifier]
     subgrid: SubgridExpression
-    statements: list[RelativeStreamDeclaration]
+    statements: list[StreamDeclaration]
 
     def validate(self) -> None:
         assert all(isinstance(var, TypedIdentifier) for var in self.variables)
-        assert all(isinstance(stmt, RelativeStreamDeclaration) for stmt in self.statements)
+        assert all(isinstance(stmt, StreamDeclaration) for stmt in self.statements)
         assert len(self.variables) == 2
 
     def get_grid_rect(self) -> tuple[int, int, int, int]:

--- a/spatialstencil/syntax/spatial_ir/language.lark
+++ b/spatialstencil/syntax/spatial_ir/language.lark
@@ -40,6 +40,7 @@ array_type : standard_type "[" value_expr ("," value_expr)* "]"
 
 // Annotations
 !annotation : "readonly" | "writeonly" | "compiletime"
+!field_decl_qualifier : "extern"
 annotations : annotation (annotation)*
 
 ?builtin_type : array_type | standard_type
@@ -112,12 +113,15 @@ subgrid_expression_2d : "[" range_expression "," range_expression "]"
 // Declarations and routing
 
 !auto : "auto"
+!direction : "in" | "out"
 hop : "(" posneg_integer_literal "," posneg_integer_literal ")"  // 2D at the moment, might expand
 hops : "[" hop ("," hop)* "]"
 routing : "hops" "=" (auto | hops) "," "channel" "=" (auto | integer_literal)
+relative_stream_declaration : "relative_stream" "(" value_expr "," value_expr ")" ("{" routing "}")?
+extern_stream_declaration : "extern_stream" "(" direction ")" ("{" routing "}")?
 
-field_declaration : builtin_type identifier  (";")? //(";" | NEWLINE)
-stream_declaration : stream_type identifier "=" "relative_stream" "(" value_expr "," value_expr ")" ("{" routing "}")?  (";")?
+field_declaration : field_decl_qualifier? builtin_type identifier  (";")? //(";" | NEWLINE)
+stream_declaration : stream_type identifier "=" (relative_stream_declaration | extern_stream_declaration) (";")?
 vars : identifier ("," identifier)*
 typed_var : scalar_type identifier
 typed_vars : typed_var ("," typed_var)*

--- a/spatialstencil/syntax/spatial_ir/lark_to_ir.py
+++ b/spatialstencil/syntax/spatial_ir/lark_to_ir.py
@@ -39,6 +39,8 @@ class TreeToSpatialIR(lark.Transformer):
     false = lambda self, _: False
     prefix = lambda self, _: None
     auto = lambda self, _: 'auto'
+    direction = lambda self, val: str(val[0])
+    field_decl_qualifier = lambda self, val: str(val[0])
 
     def NEWLINE(self, args):
         return None
@@ -162,11 +164,18 @@ class TreeToSpatialIR(lark.Transformer):
     range_expression = irnodes.RangeExpression.from_lark
 
     # Declarations and routing
+    def field_declaration(self, args):
+        is_extern = False
+        if len(args) == 3:
+            qualifier, *args = args
+            if qualifier == 'extern':
+                is_extern = True
+        return irnodes.FieldDeclaration(*args, is_extern=is_extern)
+
     def hop(self, args):
         return irnodes.RoutingHop(tuple(args))
 
     routing = irnodes.RoutingDeclaration.from_lark
-    field_declaration = irnodes.FieldDeclaration.from_lark
     subgrid_expression_2d = irnodes.SubgridExpression.from_lark
 
     def hop(self, args):
@@ -174,7 +183,13 @@ class TreeToSpatialIR(lark.Transformer):
         return irnodes.RoutingHop(o)
 
     def stream_declaration(self, args):
+        return irnodes.StreamDeclaration(*args)
+
+    def relative_stream_declaration(self, args):
         return irnodes.RelativeStreamDeclaration(*args)
+
+    def extern_stream_declaration(self, args):
+        return irnodes.ExternStreamDeclaration(*args)
 
     # Scopes
     def _scope_wrapper(self, cls, args):

--- a/spatialstencil/syntax/spatial_ir/passes.py
+++ b/spatialstencil/syntax/spatial_ir/passes.py
@@ -3,6 +3,7 @@ import warnings
 from spatialstencil.syntax.spatial_ir import irnodes as spa
 from spatialstencil.syntax.stencil_ir.type_inference import _result_type_of
 
+
 class Concretizer(spa.NodeTransformer):
 
     def __init__(self, parameters: dict[str, int]):
@@ -154,17 +155,17 @@ def constexpr_propagation(kernel: spa.Kernel) -> spa.Kernel:
 def mark_readonly_writeonly_arguments(kernel: spa.Kernel) -> spa.Kernel:
     """Marks readonly and writeonly arguments based on their usage in the kernel. Modifies the kernel in place and returns it.
     """
-    
+
     visitor = ArgumentUseVisitor()
     visitor.visit(kernel)
-    
+
     readonly = visitor.get_readonly_arguments()
     writeonly = visitor.get_writeonly_arguments()
-    
+
     for arg in kernel.arguments:
         arg.readonly = arg.identifier in readonly
         arg.writeonly = arg.identifier in writeonly
-    
+
     return kernel
 
 
@@ -177,25 +178,25 @@ class ArgumentUseVisitor(spa.NodeVisitor):
     
     Then, we can get the readonly and writeonly arguments from this.
     """
-    
+
     _arguments: set[spa.Identifier]
-    
+
     read_arguments: set[spa.Identifier]
     written_arguments: set[spa.Identifier]
-    
+
     def __init__(self):
         super().__init__()
         self._arguments = set()
         self.read_arguments = set()
         self.written_arguments = set()
-        
+
     def visit_Kernel(self, kernel: spa.Kernel):
-        
+
         for arg in kernel.arguments:
             self._arguments.add(arg.identifier)
-        
+
         self.generic_visit(kernel)
-        
+
     def visit_SendStatement(self, stmt: spa.SendStatement):
         # A send to an argument means it is "written to"
         if isinstance(stmt.stream_name, spa.ArraySlice):
@@ -205,15 +206,15 @@ class ArgumentUseVisitor(spa.NodeVisitor):
         else:
             if stmt.stream_name in self._arguments:
                 self.written_arguments.add(stmt.stream_name)
-        
+
     def visit_ReceiveStatement(self, stmt: spa.ReceiveStatement):
         # A receive from an argument means it is "read"
         self._regisiter_read(stmt)
-                
+
     def visit_ReceiveGenerator(self, gen: spa.ReceiveGenerator):
         # A receive from an argument means it is "read"
-       self._regisiter_read(gen)
-    
+        self._regisiter_read(gen)
+
     def _regisiter_read(self, s: spa.ReceiveGenerator | spa.ReceiveGenerator):
         if isinstance(s.stream_name, spa.ArraySlice):
             name = s.stream_name.array
@@ -222,9 +223,9 @@ class ArgumentUseVisitor(spa.NodeVisitor):
         else:
             if s.stream_name in self._arguments:
                 self.read_arguments.add(s.stream_name)
-    
+
     def get_readonly_arguments(self):
         return [arg for arg in self.read_arguments if arg not in self.written_arguments]
-    
+
     def get_writeonly_arguments(self):
         return [arg for arg in self.written_arguments if arg not in self.read_arguments]

--- a/tests/spatial_ir/test_argument_lowering.py
+++ b/tests/spatial_ir/test_argument_lowering.py
@@ -46,17 +46,6 @@ kernel @copy<N>(stream<f32{suffix}>[N, N] readonly a,
         assert extern_a.field_name.name == "a"
         assert extern_out.field_name.name == "out"
 
-    # Check generated equivalence classes
-    kernel = passes.concretize_parameters(kernel, N=8)
-    rects = canonicalization.consolidate_rectangles_to_equivalence_classes(kernel)
-    assert len(rects) == 1
-    rect = rects[0]
-    assert rect.x_range == (0, 8, 1)
-    assert rect.y_range == (0, 8, 1)
-    assert rect.metadata.place is not None
-    assert rect.metadata.dataflow is not None
-    assert rect.metadata.compute is not None
-
 
 @pytest.mark.parametrize("streaming", (False, True))
 def test_lower_arguments_with_scalar(streaming):

--- a/tests/spatial_ir/test_argument_lowering.py
+++ b/tests/spatial_ir/test_argument_lowering.py
@@ -1,0 +1,108 @@
+import pytest
+from spatialstencil.syntax.spatial_ir import canonicalization, irnodes as spir, parser, passes
+
+
+@pytest.mark.parametrize("streaming", (False, True))
+def test_lower_arguments(streaming):
+    suffix = ", 1" if not streaming else ""
+    kernel_code = f"""
+kernel @copy<N>(stream<f32{suffix}>[N, N] readonly a,
+               stream<f32{suffix}>[N, N] writeonly out) {{
+    place u16 i, u16 j in [0:N, 0:N] {{
+        f32 local;
+    }}
+    compute u16 i, u16 j in [0:N, 0:N] {{
+        await receive(local, a[i, j]);
+        await send(local, out[i, j]);
+    }}
+}}
+    """
+    kernel = parser.parse_string(kernel_code, "test.sptl")
+    kernel = passes.concretize_parameters(kernel, N=8)
+    rects = canonicalization.consolidate_rectangles_to_equivalence_classes(kernel)
+    assert len(rects) == 1
+    canonicalization.lower_arguments_to_extern(rects, kernel)
+
+    if streaming:
+        # Check dataflow block for extern streams
+        dataflow_block = rects[0].metadata.dataflow
+        extern_streams = [
+            stmt for stmt in dataflow_block.statements if isinstance(stmt.stream, spir.ExternStreamDeclaration)
+        ]
+        assert len(extern_streams) == 2
+        extern_a = extern_streams[0]
+        extern_out = extern_streams[1]
+        assert extern_a.stream_name.name == "a"
+        assert extern_out.stream_name.name == "out"
+        assert extern_a.stream.direction == "in"
+        assert extern_out.stream.direction == "out"
+    else:
+        # Check place block for extern fields
+        place_block = rects[0].metadata.place
+        extern_fields = [stmt for stmt in place_block.statements if stmt.is_extern]
+        assert len(extern_fields) == 2
+        extern_a = extern_fields[0]
+        extern_out = extern_fields[1]
+        assert extern_a.field_name.name == "a"
+        assert extern_out.field_name.name == "out"
+
+    # Check generated equivalence classes
+    kernel = passes.concretize_parameters(kernel, N=8)
+    rects = canonicalization.consolidate_rectangles_to_equivalence_classes(kernel)
+    assert len(rects) == 1
+    rect = rects[0]
+    assert rect.x_range == (0, 8, 1)
+    assert rect.y_range == (0, 8, 1)
+    assert rect.metadata.place is not None
+    assert rect.metadata.dataflow is not None
+    assert rect.metadata.compute is not None
+
+
+@pytest.mark.parametrize("streaming", (False, True))
+def test_lower_arguments_with_scalar(streaming):
+    suffix = ", 1" if not streaming else ""
+    kernel_code = f"""
+kernel @mult_scalar<N>(stream<f32{suffix}>[N, N] readonly a, f32 coeff, 
+                       stream<f32{suffix}>[N, N] writeonly out) {{
+    place u16 i, u16 j in [0:N, 0:N] {{
+        f32 local_a;
+    }}
+    compute u16 i, u16 j in [0:N, 0:N] {{
+        await receive(local_a, a[i, j]);
+        local_a = local_a * coeff;
+        await send(local_a, out[i, j]);
+    }}
+}}
+    """
+    kernel = parser.parse_string(kernel_code, "test.sptl")
+    kernel = passes.concretize_parameters(kernel, N=8)
+    rects = canonicalization.consolidate_rectangles_to_equivalence_classes(kernel)
+    assert len(rects) == 1
+    canonicalization.lower_arguments_to_extern(rects, kernel)
+
+    if streaming:
+        # Check dataflow block for extern streams
+        dataflow_block = rects[0].metadata.dataflow
+        extern_streams = [
+            stmt for stmt in dataflow_block.statements if isinstance(stmt.stream, spir.ExternStreamDeclaration)
+        ]
+        assert len(extern_streams) == 2
+        extern_a = extern_streams[0]
+        extern_out = extern_streams[1]
+        assert extern_a.stream_name.name == "a"
+        assert extern_out.stream_name.name == "out"
+        assert extern_a.stream.direction == "in"
+        assert extern_out.stream.direction == "out"
+    else:
+        # Check place block for extern fields
+        place_block = rects[0].metadata.place
+        extern_fields = [stmt for stmt in place_block.statements if stmt.is_extern]
+        assert len(extern_fields) == 2
+        extern_a = extern_fields[0]
+        extern_out = extern_fields[1]
+        assert extern_a.field_name.name == "a"
+        assert extern_out.field_name.name == "out"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/spatial_ir/test_spatial_ir_parser.py
+++ b/tests/spatial_ir/test_spatial_ir_parser.py
@@ -109,6 +109,50 @@ def test_spatial_roundtrip_two_phase_split():
     _rountrip_test(file)
 
 
+def test_extern_field():
+    """
+    Tests parsing the ``extern`` field qualifier in place blocks.
+    """
+    code = """
+    kernel @test<N>(f32 coeff) {
+        place u16 i, u16 j in [0:N, 0:N] {
+            extern f32[1] a;
+            f32 local_a;
+            extern f32[1] out;
+        }
+    }"""
+    kernel = parser.parse_string(code)
+    place_block = next(stmt for stmt in kernel.body if isinstance(stmt, spast.PlaceBlock))
+    a_decl, local_a_decl, out_decl = place_block.statements
+    assert not local_a_decl.is_extern
+    assert a_decl.is_extern
+    assert out_decl.is_extern
+
+
+def test_extern_stream():
+    """
+    Tests parsing the ``extern_stream`` stream in dataflow blocks.
+    """
+    code = """
+    kernel @test<N>(f32 coeff) {
+        dataflow u16 i, u16 j in [0:N, 0:N] {
+            stream<f32> in_stream = extern_stream(in);
+            stream<f32> out_stream = extern_stream(out) {
+                hops = auto,
+                channel = 3
+            };
+        }
+    }"""
+    kernel = parser.parse_string(code)
+    df_block = next(stmt for stmt in kernel.body if isinstance(stmt, spast.DataflowBlock))
+    in_decl, out_decl = df_block.statements
+    assert isinstance(in_decl.stream, spast.ExternStreamDeclaration)
+    assert isinstance(out_decl.stream, spast.ExternStreamDeclaration)
+    assert in_decl.stream.direction == 'in'
+    assert out_decl.stream.direction == 'out'
+    assert out_decl.stream.routing.channel == 3
+
+
 if __name__ == '__main__':
     test_spatial_roundtrip_laplacian()
     test_spatial_visitor()
@@ -117,3 +161,5 @@ if __name__ == '__main__':
     test_spatial_roundtrip_two_phase_split()
     test_spatial_roundtrip_forward()
     test_spatial_roundtrip_backward()
+    test_extern_field()
+    test_extern_stream()

--- a/tests/spatial_ir/test_spatial_ir_passes.py
+++ b/tests/spatial_ir/test_spatial_ir_passes.py
@@ -1,6 +1,5 @@
-import unittest
-
-from spatialstencil.syntax.spatial_ir import irnodes as spir, canonicalization
+import pytest
+from spatialstencil.syntax.spatial_ir import irnodes as spir, canonicalization, parser
 
 
 def test_canonicalize_nochange():
@@ -81,9 +80,8 @@ def test_canonicalize_multiphase():
                 spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('j', 0))
             ], spir.SubgridExpression(_make_range(20, 30), _make_range(0, 30)), [
                 spir.StreamDeclaration(
-                    spir.StreamType(spir.ScalarType.f32), spir.Identifier('s', 0), 
-                    spir.RelativeStreamDeclaration(_make_number(1), _make_number(-1))
-                )
+                    spir.StreamType(spir.ScalarType.f32), spir.Identifier('s', 0),
+                    spir.RelativeStreamDeclaration(_make_number(1), _make_number(-1)))
             ])
         ])
     ckernel = canonicalization.canonicalize_phases(kernel)
@@ -114,7 +112,49 @@ def _make_range(start: int, end: int):
     return spir.RangeExpression(_make_number(start), _make_number(end))
 
 
+@pytest.mark.parametrize("should_lower", [True, False])
+def test_lower_to_for(should_lower: bool):
+    stream = 'b' if should_lower else 'red'
+    kernel_str = f"""
+      kernel @test<>() {{
+          place i16 i, i16 j in [0:4, 0:4] {{
+              f32[8] a
+              f32[8] b
+          }}
+          dataflow i16 i, i16 j in [0:4 , 0:4] {{
+              stream<f32> red = relative_stream(-1, 0) {{
+                  hops = [(-1, 0)],
+                  channel = 0
+              }}
+              stream<f32> blue = relative_stream(-1, 0) {{
+                  hops = [(-1, 0)],
+                  channel = 1
+              }}
+          }}
+          compute i16 i, i16 j in [0:4, 0:4] {{
+              await foreach i16 k, f32 x in [0:8], receive({stream}) {{
+                  a[k] = a[k] + x
+                  await send(a[k], blue)
+              }}
+          }}
+      }}"""
+    kernel = parser.parse_string(kernel_str, "test.sptl")
+    rects = canonicalization.consolidate_rectangles_to_equivalence_classes(kernel)
+    assert len(rects) == 1
+    rect = rects[0]
+    dtypes = {decl.field_name: decl.dtype for decl in rect.metadata.place.statements}
+    dtypes.update({decl.stream_name: decl.dtype for decl in rect.metadata.dataflow.statements})
+    canonicalization.convert_foreach_data_tasks_to_loops(rect, dtypes)
+    if should_lower:
+        assert not any(isinstance(stmt, spir.ForeachStatement) for stmt in rect.metadata.compute.statements)
+    else:
+        # There should still be a data task here
+        assert any(isinstance(stmt, spir.ForeachStatement) for stmt in rect.metadata.compute.statements)
+
+
 if __name__ == '__main__':
     test_canonicalize_nochange()
     test_canonicalize_singlephase()
     test_canonicalize_multiphase()
+    test_lower_to_for(False)
+    test_lower_to_for(True)

--- a/tests/spatial_ir/test_spatial_ir_passes.py
+++ b/tests/spatial_ir/test_spatial_ir_passes.py
@@ -20,23 +20,26 @@ def test_canonicalize_singlephase():
         parameters=[],
         arguments=[],
         body=[
-            spir.DataflowBlock([spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('i', 0)), 
-                                spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('j', 0))],
-                               spir.SubgridExpression(_make_range(0, 20), _make_range(0, 30)), [
-                                   spir.RelativeStreamDeclaration(
-                                       spir.StreamType(spir.ScalarType.f32), spir.Identifier('s', 0), _make_number(-1),
-                                       _make_number(1))
-                               ]),
-            spir.ComputeBlock([spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('i', 0)), 
-                               spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('j', 0))],
-                              spir.SubgridExpression(_make_range(0, 30), _make_range(0, 30)), []),
-            spir.DataflowBlock([spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('i', 0)), 
-                                spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('j', 0))],
-                               spir.SubgridExpression(_make_range(20, 30), _make_range(0, 30)), [
-                                   spir.RelativeStreamDeclaration(
-                                       spir.StreamType(spir.ScalarType.f32), spir.Identifier('s', 0), _make_number(1),
-                                       _make_number(-1))
-                               ])
+            spir.DataflowBlock([
+                spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('i', 0)),
+                spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('j', 0))
+            ], spir.SubgridExpression(_make_range(0, 20), _make_range(0, 30)), [
+                spir.StreamDeclaration(
+                    spir.StreamType(spir.ScalarType.f32), spir.Identifier('s', 0),
+                    spir.RelativeStreamDeclaration(_make_number(-1), _make_number(1)))
+            ]),
+            spir.ComputeBlock([
+                spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('i', 0)),
+                spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('j', 0))
+            ], spir.SubgridExpression(_make_range(0, 30), _make_range(0, 30)), []),
+            spir.DataflowBlock([
+                spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('i', 0)),
+                spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('j', 0))
+            ], spir.SubgridExpression(_make_range(20, 30), _make_range(0, 30)), [
+                spir.StreamDeclaration(
+                    spir.StreamType(spir.ScalarType.f32), spir.Identifier('s', 0),
+                    spir.RelativeStreamDeclaration(_make_number(1), _make_number(-1)))
+            ])
         ])
     ckernel = canonicalization.canonicalize_phases(kernel)
     assert ckernel.as_ir() == '''kernel @test<>() {
@@ -60,24 +63,28 @@ def test_canonicalize_multiphase():
         parameters=[],
         arguments=[],
         body=[
-            spir.DataflowBlock([spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('i', 0)), 
-                                spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('j', 0))],
-                               spir.SubgridExpression(_make_range(0, 20), _make_range(0, 30)), [
-                                   spir.RelativeStreamDeclaration(
-                                       spir.StreamType(spir.ScalarType.f32), spir.Identifier('s', 0), _make_number(-1),
-                                       _make_number(1))
-                               ]),
-            spir.ComputeBlock([spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('i', 0)), 
-                               spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('j', 0))],
-                              spir.SubgridExpression(_make_range(0, 30), _make_range(0, 30)), []),
+            spir.DataflowBlock([
+                spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('i', 0)),
+                spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('j', 0))
+            ], spir.SubgridExpression(_make_range(0, 20), _make_range(0, 30)), [
+                spir.StreamDeclaration(
+                    spir.StreamType(spir.ScalarType.f32), spir.Identifier('s', 0),
+                    spir.RelativeStreamDeclaration(_make_number(-1), _make_number(1)))
+            ]),
+            spir.ComputeBlock([
+                spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('i', 0)),
+                spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('j', 0))
+            ], spir.SubgridExpression(_make_range(0, 30), _make_range(0, 30)), []),
             spir.Phase([], [], []),
-            spir.DataflowBlock([spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('i', 0)), 
-                                spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('j', 0))],
-                               spir.SubgridExpression(_make_range(20, 30), _make_range(0, 30)), [
-                                   spir.RelativeStreamDeclaration(
-                                       spir.StreamType(spir.ScalarType.f32), spir.Identifier('s', 0), _make_number(1),
-                                       _make_number(-1))
-                               ])
+            spir.DataflowBlock([
+                spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('i', 0)),
+                spir.TypedIdentifier(spir.ScalarType.i16, spir.Identifier('j', 0))
+            ], spir.SubgridExpression(_make_range(20, 30), _make_range(0, 30)), [
+                spir.StreamDeclaration(
+                    spir.StreamType(spir.ScalarType.f32), spir.Identifier('s', 0), 
+                    spir.RelativeStreamDeclaration(_make_number(1), _make_number(-1))
+                )
+            ])
         ])
     ckernel = canonicalization.canonicalize_phases(kernel)
     assert ckernel.as_ir() == '''kernel @test<>() {


### PR DESCRIPTION
During lowering to hardware, arguments are lowered into explicit `place` fields or `extern_stream`s depending on the mode of operation.

 In memcpy mode:
```rust
place ... {
   extern f16[K] inp;
}
```
In streaming mode:
```rust
dataflow ... {
  stream<f16, K> inp = extern_stream(in) { /*routing data*/ };
  stream<f16, K> out = extern_stream(out) { /*routing data*/ };
}
```

- [x] Implement syntax and tree nodes for external streams and fields
- [x] Lowering pass
- [x] CSL code generation support
    - [x] `extern` --> `export`
    - [x] Proper DSD management
    - [x] Benchmarking infrastructure redone as extern fields
    - [x] Go over all uses of `kernel.arguments` for cleanup