### PR TITLE
Support capturing relay DSD operations

### DIFF
--- a/spatialstencil/lowering/spatial_ir_to_csl.py
+++ b/spatialstencil/lowering/spatial_ir_to_csl.py
@@ -13,7 +13,7 @@ from spatialstencil.syntax.spatial_ir import canonical_subgrids
 from spatialstencil.syntax.spatial_ir.canonicalization import PEBlock, Rectangle
 from spatialstencil.syntax.csl import constants as csl, preprocessing, tasks as tdag, statements as cslstmt, dsd_ops
 from spatialstencil.syntax.csl import structures as cslstruct
-from spatialstencil.syntax.csl import task_recycling
+from spatialstencil.syntax.csl import task_recycling, prune_unused_fields as csl_pruning
 from spatialstencil.syntax.csl.codefile import CodeFile
 from spatialstencil.syntax.csl.statements import name_to_csl, dtype_as_csl, expr_to_csl
 
@@ -352,7 +352,7 @@ const sys_mod = @import_module("<memcpy/memcpy>", memcpy_params);
         task_creation_behavior = tdag.TaskCreationBehavior.STATE_MACHINE_ON_OVERRUN
     tasks = tdag.create_csl_tasks(completion_dag, rect.metadata.compute, dtypes, task_creation_behavior)
 
-    copy_elimination.prune_unused_place_fields_for_csl_codegen(rect.metadata, dtypes)
+    csl_pruning.prune_unused_place_fields_for_csl_codegen(rect.metadata, dtypes)
     _collect_and_generate_fields(rect.metadata.place, header, footer, kernel, use_memcpy_mode)
     dtypes = _collect_identifier_types(rect.metadata, kernel.arguments)
 
@@ -746,7 +746,6 @@ def _collect_and_generate_fields(place: spir.PlaceBlock, header: StringIO, foote
         header.write(f'var {name}: {dtype_as_csl(argument.dtype)};\n')
 
     header.write('\n')
-
 
 
 def _dsd_from_array(array_candidates: dict[str, tuple[spir.FieldDeclaration, list[int | spir.Expression]]],

--- a/spatialstencil/lowering/spatial_ir_to_csl.py
+++ b/spatialstencil/lowering/spatial_ir_to_csl.py
@@ -322,12 +322,12 @@ const sys_mod = @import_module("<memcpy/memcpy>", memcpy_params);
     #     * Generate routing instructions from dataflow blocks
     #     * Make unique colors out of streams, reduce number of streams
     color_map = _allocate_colors(rect, header, kernel, use_memcpy_mode, stream_extents, channel_to_color)
-    _collect_and_generate_fields(rect.metadata.place, header, footer, kernel, use_memcpy_mode)
     dtypes = _collect_identifier_types(rect.metadata, kernel.arguments)
 
     # Preprocess potential data tasks to convert to loops if possible
     if use_memcpy_mode:
         canonicalization.convert_foreach_data_tasks_to_loops(rect, dtypes)
+        dtypes = _collect_identifier_types(rect.metadata, kernel.arguments)
 
     if not disable_benchmarking:
         benchmark_preamble, benchmark_postamble = _generate_benchmarking_code(header)
@@ -351,6 +351,11 @@ const sys_mod = @import_module("<memcpy/memcpy>", memcpy_params);
     else:
         task_creation_behavior = tdag.TaskCreationBehavior.STATE_MACHINE_ON_OVERRUN
     tasks = tdag.create_csl_tasks(completion_dag, rect.metadata.compute, dtypes, task_creation_behavior)
+
+    copy_elimination.prune_unused_place_fields_for_csl_codegen(rect.metadata, dtypes)
+    _collect_and_generate_fields(rect.metadata.place, header, footer, kernel, use_memcpy_mode)
+    dtypes = _collect_identifier_types(rect.metadata, kernel.arguments)
+
     try:
         dsds = _collect_unique_dsds(tasks, rect.metadata, header, dtypes, kernel, use_memcpy_mode)
     except KeyError as e:
@@ -741,6 +746,7 @@ def _collect_and_generate_fields(place: spir.PlaceBlock, header: StringIO, foote
         header.write(f'var {name}: {dtype_as_csl(argument.dtype)};\n')
 
     header.write('\n')
+
 
 
 def _dsd_from_array(array_candidates: dict[str, tuple[spir.FieldDeclaration, list[int | spir.Expression]]],

--- a/spatialstencil/syntax/csl/dsd_ops.py
+++ b/spatialstencil/syntax/csl/dsd_ops.py
@@ -40,11 +40,15 @@ class DSDOp:
             dsds = copy.copy(dsds)
             dsds[statement.stream_variable.identifier.as_ir()] = dsds[_ident(
                 statement.receive_stream.stream_name).as_ir()]
-            statement = statement.body[0]
-        elif hasattr(statement, 'body'):
-            statement = statement.body[0]
-        dsd_objects = self.used_dsd_objects(statement, dsds)
-        return self._append_async_suffix(self._as_csl(statement, dtypes, dsds), dsd_objects, async_target)
+        normalized_statement: Optional[spir.AssignmentStatement | spir.SendStatement]
+        if isinstance(statement, (spir.AssignmentStatement, spir.SendStatement)):
+            normalized_statement = statement
+        else:
+            normalized_statement = get_dsd_statement(dtypes, statement)
+        if normalized_statement is None:
+            raise ValueError('Expected a statement that can be lowered to a DSD operation')
+        dsd_objects = self.used_dsd_objects(normalized_statement, dsds)
+        return self._append_async_suffix(self._as_csl(normalized_statement, dtypes, dsds), dsd_objects, async_target)
 
     def _as_csl(self, statement: spir.Statement, dtypes: dict[spir.Identifier, spir.IRType],
                 dsds: UniqueDSDDict) -> str:
@@ -263,6 +267,7 @@ class FMADSDOp(DSDOp):
 
 
 class CopyDSDOp(DSDOp):
+
     def __init__(self, scalar_input: bool = False):
         super().__init__()
         self.scalar_input = scalar_input
@@ -398,7 +403,55 @@ def _get_base_dtype(dtypes: dict[str, spir.IRType],
         dtype = dtype.element_type
     return dtype
 
+
+def _is_stream_backed_dtype(dtype: spir.IRType) -> bool:
+    if isinstance(dtype, spir.StreamType):
+        return True
+    if isinstance(dtype, spir.ArrayType):
+        return _is_stream_backed_dtype(dtype.base_type)
+    return False
+
+
+def _make_relay_dsd_statement(dtypes: dict[spir.Identifier, spir.IRType],
+                              stmt: spir.ForeachStatement) -> Optional[spir.AssignmentStatement]:
+    if len(stmt.body) != 2:
+        return None
+
+    first_stmt, second_stmt = stmt.body
+    if not isinstance(first_stmt, spir.AssignmentStatement) or not isinstance(second_stmt, spir.SendStatement):
+        return None
+
+    receive_dtype = _get_dtype(dtypes, stmt.receive_stream.stream_name)
+    if not _is_stream_backed_dtype(receive_dtype):
+        return None
+
+    if first_stmt.destination.as_ir() != second_stmt.local_array.as_ir():
+        return None
+
+    relay_stmt = spir.AssignmentStatement(copy.deepcopy(second_stmt.stream_name), copy.deepcopy(first_stmt.source))
+    return relay_stmt
+
+
+def get_dsd_statement(dtypes: dict[spir.Identifier, spir.IRType],
+                      stmt: spir.Statement) -> Optional[spir.AssignmentStatement]:
+    if isinstance(stmt, spir.AssignmentStatement):
+        return stmt
+
+    if not hasattr(stmt, 'body'):
+        return None
+
+    if len(stmt.body) == 0:
+        return None
+    if len(stmt.body) == 1 and isinstance(stmt.body[0], spir.AssignmentStatement):
+        return stmt.body[0]
+    if isinstance(stmt, spir.ForeachStatement):
+        return _make_relay_dsd_statement(dtypes, stmt)
+    return None
+
+
 DISABLE_DSD = False
+
+
 def get_dsd_op(dtypes: dict[spir.Identifier, spir.IRType],
                stmt: spir.ForeachStatement | spir.MapStatement | spir.AssignmentStatement) -> Optional[str]:
     """
@@ -409,17 +462,13 @@ def get_dsd_op(dtypes: dict[spir.Identifier, spir.IRType],
     """
     if DISABLE_DSD:
         return None
-    if isinstance(stmt, spir.AssignmentStatement):
-        inner_stmt = stmt
-    else:
-        if len(stmt.body) == 0:
-            # No-op
-            return ''
-        if len(stmt.body) > 1:
-            return None
-        inner_stmt = stmt.body[0]
-        if not isinstance(inner_stmt, spir.AssignmentStatement):
-            return None
+    if not isinstance(stmt, spir.AssignmentStatement) and len(stmt.body) == 0:
+        # No-op
+        return ''
+
+    inner_stmt = get_dsd_statement(dtypes, stmt)
+    if inner_stmt is None:
+        return None
 
     dst = _get_id(inner_stmt.destination)
     if dst not in dtypes:

--- a/spatialstencil/syntax/csl/prune_unused_fields.py
+++ b/spatialstencil/syntax/csl/prune_unused_fields.py
@@ -1,0 +1,37 @@
+"""
+Support module for copy elimination in the CSL codegen backend.
+Shares logic with the more general copy elimination pass, but specializes for DSD operations.
+"""
+from spatialstencil.syntax.csl import dsd_ops
+from spatialstencil.syntax.spatial_ir import irnodes as spir
+from spatialstencil.syntax.spatial_ir.canonicalization import PEBlock
+from spatialstencil.syntax.spatial_ir.copy_elimination import _FieldUseCollector
+
+
+def _effective_statement_for_csl_codegen(
+    stmt: spir.Statement,
+    dtypes: dict[spir.Identifier, spir.IRType],
+) -> spir.Statement:
+    """Return the statement shape that CSL lowering will actually emit."""
+
+    if isinstance(stmt, (spir.ForeachStatement, spir.MapStatement)):
+        if dsd_ops.get_dsd_op(dtypes, stmt) is not None:
+            dsd_stmt = dsd_ops.get_dsd_statement(dtypes, stmt)
+            if dsd_stmt is not None:
+                return dsd_stmt
+    return stmt
+
+
+def prune_unused_place_fields_for_csl_codegen(
+    rect: PEBlock,
+    dtypes: dict[spir.Identifier, spir.IRType],
+) -> None:
+    """Drop non-extern fields that disappear during CSL DSD lowering."""
+    declared_fields = {decl.field_name for decl in rect.place.statements}
+    used_fields = _FieldUseCollector(declared_fields)
+    for stmt in rect.compute.statements:
+        used_fields.visit(_effective_statement_for_csl_codegen(stmt, dtypes))
+
+    rect.place.statements = [
+        decl for decl in rect.place.statements if decl.is_extern or decl.field_name in used_fields.used_fields
+    ]

--- a/spatialstencil/syntax/csl/tasks.py
+++ b/spatialstencil/syntax/csl/tasks.py
@@ -461,8 +461,10 @@ def fuse_tasks(tasks: list[CSLTask], dsds: UniqueDSDDict, dtypes: dict[spir.Iden
             if dsd_op is None:
                 continue
             # Pure memory DSD operations are synchronous and can be fused
-            assert len(stmt.body) == 1
-            dsd_objects = dsd_op().used_dsd_objects(stmt.body[0], dsds)
+            dsd_stmt = dsd_ops.get_dsd_statement(dtypes, stmt)
+            if dsd_stmt is None:
+                continue
+            dsd_objects = dsd_op().used_dsd_objects(dsd_stmt, dsds)
             if any(isinstance(dsd, cslstruct.FabricDSD) for dsd in dsd_objects):
                 continue
             # Also check the foreach receive generator

--- a/spatialstencil/syntax/spatial_ir/copy_elimination.py
+++ b/spatialstencil/syntax/spatial_ir/copy_elimination.py
@@ -1122,38 +1122,6 @@ class RemoveSingleElementIndexCopies:
             )
 
 
-# This should be in another file, but it shares some logic with the copy elimination passes.
-def _effective_statement_for_csl_codegen(
-    stmt: spir.Statement,
-    dtypes: dict[spir.Identifier, spir.IRType],
-) -> spir.Statement:
-    """Return the statement shape that CSL lowering will actually emit."""
-    from spatialstencil.syntax.csl import dsd_ops
-
-    if isinstance(stmt, (spir.ForeachStatement, spir.MapStatement)):
-        if dsd_ops.get_dsd_op(dtypes, stmt) is not None:
-            dsd_stmt = dsd_ops.get_dsd_statement(dtypes, stmt)
-            if dsd_stmt is not None:
-                return dsd_stmt
-    return stmt
-
-
-# This should be in another file, but it shares some logic with the copy elimination passes.
-def prune_unused_place_fields_for_csl_codegen(
-    rect: PEBlock,
-    dtypes: dict[spir.Identifier, spir.IRType],
-) -> None:
-    """Drop non-extern fields that disappear during CSL DSD lowering."""
-    declared_fields = {decl.field_name for decl in rect.place.statements}
-    used_fields = _FieldUseCollector(declared_fields)
-    for stmt in rect.compute.statements:
-        used_fields.visit(_effective_statement_for_csl_codegen(stmt, dtypes))
-
-    rect.place.statements = [
-        decl for decl in rect.place.statements if decl.is_extern or decl.field_name in used_fields.used_fields
-    ]
-
-
 def prune_unused_fields(rectangles: list[Rectangle[PEBlock]]) -> None:
     """Public helper that runs ``PruneUnusedFields``."""
     PruneUnusedFields().apply(rectangles)

--- a/spatialstencil/syntax/spatial_ir/copy_elimination.py
+++ b/spatialstencil/syntax/spatial_ir/copy_elimination.py
@@ -1122,6 +1122,38 @@ class RemoveSingleElementIndexCopies:
             )
 
 
+# This should be in another file, but it shares some logic with the copy elimination passes.
+def _effective_statement_for_csl_codegen(
+    stmt: spir.Statement,
+    dtypes: dict[spir.Identifier, spir.IRType],
+) -> spir.Statement:
+    """Return the statement shape that CSL lowering will actually emit."""
+    from spatialstencil.syntax.csl import dsd_ops
+
+    if isinstance(stmt, (spir.ForeachStatement, spir.MapStatement)):
+        if dsd_ops.get_dsd_op(dtypes, stmt) is not None:
+            dsd_stmt = dsd_ops.get_dsd_statement(dtypes, stmt)
+            if dsd_stmt is not None:
+                return dsd_stmt
+    return stmt
+
+
+# This should be in another file, but it shares some logic with the copy elimination passes.
+def prune_unused_place_fields_for_csl_codegen(
+    rect: PEBlock,
+    dtypes: dict[spir.Identifier, spir.IRType],
+) -> None:
+    """Drop non-extern fields that disappear during CSL DSD lowering."""
+    declared_fields = {decl.field_name for decl in rect.place.statements}
+    used_fields = _FieldUseCollector(declared_fields)
+    for stmt in rect.compute.statements:
+        used_fields.visit(_effective_statement_for_csl_codegen(stmt, dtypes))
+
+    rect.place.statements = [
+        decl for decl in rect.place.statements if decl.is_extern or decl.field_name in used_fields.used_fields
+    ]
+
+
 def prune_unused_fields(rectangles: list[Rectangle[PEBlock]]) -> None:
     """Public helper that runs ``PruneUnusedFields``."""
     PruneUnusedFields().apply(rectangles)

--- a/tests/spatial_ir/test_csl_tasks.py
+++ b/tests/spatial_ir/test_csl_tasks.py
@@ -1,6 +1,6 @@
 import pytest
 from spatialstencil.lowering import spatial_ir_to_csl as s2c
-from spatialstencil.syntax.spatial_ir import analysis, parser, irnodes
+from spatialstencil.syntax.spatial_ir import analysis, parser
 from spatialstencil.syntax.spatial_ir.canonicalization import PEBlock
 from spatialstencil.syntax.csl import tasks as tdag
 
@@ -90,6 +90,38 @@ kernel @reduce<N>(stream<f32>[N] readonly inp, stream<f32> writeonly out) {
     assert len(tasks) in (5, 6)
     assert len(tasks[0].statements) == 5
     assert len(tasks[-1].statements) == 1
+
+
+def test_tasks_with_relay_dsd_op():
+    kernel = parser.parse_string(code="""
+kernel @relay<>() {
+
+    place i16 i, i16 j in [0, 0] {
+        f32[8] a
+    }
+    dataflow i16 i, i16 j in [0, 0] {
+        stream<f32> red = relative_stream(-1, 0) {
+            hops = [(-1, 0)],
+            channel = 0
+        }
+        stream<f32> blue = relative_stream(1, 0) {
+            hops = [(1, 0)],
+            channel = 1
+        }
+    }
+    compute i16 i, i16 j in [0, 0] {
+        await foreach i16 k, f32 x in [0:8], receive(red) {
+            a[k] = a[k] + x
+            await send(a[k], blue)
+        }
+    }
+}""")
+    place, dataflow, compute = kernel.body
+    block = PEBlock(place, dataflow, compute)
+    tasks = _create_tasks(block)
+
+    assert len(tasks) == 1
+    assert tasks[0].task_type == 'local'
 
 
 @pytest.mark.parametrize('async_first_task', (False, True))

--- a/tests/spatial_ir/test_dsd_ops.py
+++ b/tests/spatial_ir/test_dsd_ops.py
@@ -97,6 +97,41 @@ kernel @tester<K> () {{
     assert dsd_ops.get_dsd_op(dtypes, compute.statements[0]) == "@fmuls"
 
 
+def test_dsd_op_detection_receive_op_send():
+    kernel = parser.parse_string(code="""
+kernel @tester<K>() {
+
+    place i16 i, i16 j in [0, 0] {
+        f32[K] a32
+    }
+    dataflow i16 i, i16 j in [0, 0] {
+        stream<f32> red = relative_stream(-1, 0) {
+            hops = [(-1, 0)],
+            channel = 0
+        }
+        stream<f32> blue = relative_stream(1, 0) {
+            hops = [(1, 0)],
+            channel = 1
+        }
+    }
+    compute i16 i, i16 j in [0, 0] {
+        await foreach i16 k, f32 x in [0:K], receive(red) {
+            a32[k] = a32[k] + x
+            await send(a32[k], blue)
+        }
+    }
+}""")
+    kernel = passes.concretize_parameters(kernel, K=8)
+    place, dataflow, compute = kernel.body
+    dtypes = s2c._collect_identifier_types(PEBlock(place, dataflow, compute), [])
+
+    assert dsd_ops.get_dsd_op(dtypes, compute.statements[0]) == "@fadds"
+    dsd_stmt = dsd_ops.get_dsd_statement(dtypes, compute.statements[0])
+    assert dsd_stmt is not None
+    assert dsd_stmt.destination.as_ir() == 'blue'
+
+
 if __name__ == '__main__':
     test_dsd_op_detection()
     test_dsd_op_detection_constant_folding()
+    test_dsd_op_detection_receive_op_send()

--- a/tests/spatial_ir/test_lowering_statements_to_csl.py
+++ b/tests/spatial_ir/test_lowering_statements_to_csl.py
@@ -1025,6 +1025,50 @@ def test_foreach_lifting_to_dsd_op(with_binop):
     assert dsd_found, "Expected DSD operations not found in generated CSL"
 
 
+def test_foreach_receive_op_send_lifting_to_dsd_op():
+    spatial_ir_code = '''
+    kernel @test_foreach_relay<>() {
+        place u16 i, u16 j in [0:1, 0:1] {
+            f32[8] local_val;
+        }
+        dataflow u16 i, u16 j in [0:1, 0:1] {
+            stream<f32> input = relative_stream(-1, 0) {
+                hops = [(-1, 0)],
+                channel = 0
+            }
+            stream<f32> output = relative_stream(1, 0) {
+                hops = [(1, 0)],
+                channel = 1
+            }
+        }
+        compute u16 i, u16 j in [0:1, 0:1] {
+            await foreach u16 k, f32 inp in [0:8], receive(input) {
+                local_val[k] = local_val[k] + inp;
+                await send(local_val[k], output);
+            };
+        }
+    }
+    '''
+
+    kernel = create_inline_spatial_ir(spatial_ir_code)
+    kernel = passes.constexpr_propagation(kernel)
+
+    csl_files = lower_spatial_ir_to_csl(kernel, copy_elision=False)
+
+    assert len(csl_files) > 0
+
+    dsd_found = False
+    data_task_found = False
+    for f in csl_files:
+        if '@fadds' in f.code:
+            dsd_found = True
+        if 'data_task' in f.code and 'local_val[k] = local_val[k] + inp' in f.code:
+            data_task_found = True
+
+    assert dsd_found, "Expected relay DSD operation not found in generated CSL"
+    assert not data_task_found, "Relay foreach should not be lowered as a data task"
+
+
 if __name__ == '__main__':
     test_receive_statement_scalar()
     test_receive_statement_array()

--- a/tests/spatial_ir/test_lowering_statements_to_csl.py
+++ b/tests/spatial_ir/test_lowering_statements_to_csl.py
@@ -838,13 +838,11 @@ def test_map_lifting_to_dsd_op(multidimensional):
     assert len(csl_files) > 0
 
     # Look for map lifting to DSD operations
-    dsd_found = False
     for f in csl_files:
         if '@fmuls' in f.code:
-            dsd_found = True
             break
-
-    assert dsd_found, "Expected DSD operations not found in generated CSL"
+    else:
+        raise AssertionError("Expected DSD operations not found in generated CSL")
 
     # Check for the DSD structure (dimensionality)
     if multidimensional:

--- a/tests/spatial_ir/test_spatial_ir_passes.py
+++ b/tests/spatial_ir/test_spatial_ir_passes.py
@@ -304,6 +304,7 @@ def test_lower_to_for(should_lower: bool):
           compute i16 i, i16 j in [0:4, 0:4] {{
               await foreach i16 k, f32 x in [0:8], receive({stream}) {{
                   a[k] = a[k] + x
+                  a[k] = a[k] + x
                   await send(a[k], blue)
               }}
           }}


### PR DESCRIPTION
Supports DSD generation of ops of the form `receive->operator->send`.
Also fixes a pass ordering issue where pruned fields would still appear in generated CSL code.