### PR TITLE
Fix: task lowering empty task

### DIFF
--- a/spatialstencil/syntax/csl/tasks.py
+++ b/spatialstencil/syntax/csl/tasks.py
@@ -117,7 +117,6 @@ def create_csl_tasks(
     # Loop over completion DAG to coarsen completions to tasks
     for cnode in nx.topological_sort(completion_dag):
         node = block.statements[cnode.statement_id]
-
         # Figure out whether this task type is a local task or a data task
         if (isinstance(node, spir.ForeachStatement) and dsd_ops.get_dsd_op(dtypes, node) is None and
                 cnode.optype == 'post'):
@@ -260,13 +259,18 @@ def create_csl_tasks(
             pred_task = cnode_to_task_id[pred]
             if pred_task == stmt_task:  # Skip sequential edges
                 continue
+            # Predecessor lived on the contracted empty last task; no task slot remains for it.
+            if pred_task >= len(result):
+                continue
 
             has_edge = any(e == stmt_task for e, _ in result[pred_task].outgoing)
             if not has_edge:
                 task = result[pred_task]
                 if task.task_type == "local":
                     task.statements.append("TERMINATOR")
-                    if stmt_task in task_has_activate or result[stmt_task].task_type == 'data':
+                    # After contracting an empty trailing task, stmt_task may equal len(result), meaning exit.
+                    succ_is_data = stmt_task < len(result) and result[stmt_task].task_type == 'data'
+                    if stmt_task in task_has_activate or succ_is_data:
                         task.outgoing.append((stmt_task, InterTaskEdge.UNBLOCK))
                     else:
                         task.outgoing.append((stmt_task, InterTaskEdge.ACTIVATE))

--- a/tests/spatial_ir/test_lowering_spatial_ir_to_csl.py
+++ b/tests/spatial_ir/test_lowering_spatial_ir_to_csl.py
@@ -100,6 +100,17 @@ def test_two_phase_split():
         print('=============')
 
 
+def test_neighbor_exchange_lowers():
+    """``neighbor_exchange.sptl`` lowers to CSL without errors (neighbor send/receive)."""
+    file = os.path.join(os.path.dirname(__file__), 'samples', 'neighbor_exchange.sptl')
+    kernel = parser.parse_file(file)
+    kernel = passes.concretize_parameters(kernel, K=4)
+    kernel = passes.constexpr_propagation(kernel)
+    csl_files = lower_spatial_ir_to_csl(kernel)
+    assert csl_files, 'expected at least one generated CSL file'
+    assert all(f.code.strip() for f in csl_files), 'expected non-empty CSL bodies'
+
+
 def test_laplacian():
     file = os.path.join(os.path.dirname(__file__), '..', '..', 'samples', 'spatial', 'stencils', 'laplacian_routed.sptl')
     kernel = parser.parse_file(file)
@@ -136,5 +147,6 @@ if __name__ == '__main__':
     for _fname, _params in _COLLECTIVES_2D:
         test_collective_2d(_fname, _params)
     test_two_phase_split()
+    test_neighbor_exchange_lowers()
     test_laplacian()
     test_forward_sum()


### PR DESCRIPTION
After this block removes the last task when it is local and has no statements:

```tasks.py
    # tasks.py
    # Lines 250-252
    # If the last task is local and empty, we can contract it with our exit task
    if len(result) > 0 and not result[-1].statements:
        result = result[:-1]
```

cnode_to_task_id is not updated. Completion nodes that still belonged to that removed task keep task id k where k == len(result) after the slice. Elsewhere in the same function, target == len(result) is already used as the exit sentinel (see the loop around lines 309–312), so that id is valid as a target but not as result[stmt_task]. The terminator pass always did result[stmt_task], which produced IndexError when stmt_task == len(result).

Fixes:

Terminator pass: If pred_task >= len(result), skip (predecessor only lived on the contracted task; there is no result[pred_task]).

Successor type: Use result[stmt_task] only when stmt_task < len(result); otherwise treat the successor as exit (not a data task).