### PR TITLE
Add support for disabling copy elision

### DIFF
--- a/spatialstencil/cli/compiler.py
+++ b/spatialstencil/cli/compiler.py
@@ -22,10 +22,11 @@ import subprocess
 @click.option('--disable-map', is_flag=True, help='Disable @map operation detection and code generation')
 @click.option('--disable-task-fusion', is_flag=True, help='Disable task fusion optimization')
 @click.option('--disable-task-recycling', is_flag=True, help='Disable task ID recycling')
+@click.option('--disable-copy-elision', is_flag=True, help='Disable copy elimination optimization pass')
 def compile_spatial_ir(input_file: str, output_folder: str, param: list[str], offset_x: int, offset_y: int,
                        generate_only: bool, disable_benchmarking: bool, sync_benchmarking: bool,
                        disable_asynchronous: bool, disable_dsd: bool, disable_map: bool,
-                       disable_task_fusion: bool, disable_task_recycling: bool):
+                       disable_task_fusion: bool, disable_task_recycling: bool, disable_copy_elision: bool):
     if disable_benchmarking and sync_benchmarking:
         raise click.UsageError("--sync-benchmarking cannot be used with --disable-benchmarking")
 
@@ -97,6 +98,7 @@ def compile_spatial_ir(input_file: str, output_folder: str, param: list[str], of
         disable_asynchronous=disable_asynchronous,
         disable_dsd=disable_dsd,
         task_fusion=not disable_task_fusion,
+        copy_elision=not disable_copy_elision,
         task_id_recycling=not disable_task_recycling,
     )
 

--- a/tests/csl_runtime/test_twophase_reduce_1d.sh
+++ b/tests/csl_runtime/test_twophase_reduce_1d.sh
@@ -12,16 +12,25 @@ S=4   # must be even
 K=4
 FOLDER="twophase_reduce_1d_sptl"
 
-sptlc "$COLLECTIVES_DIR/twophase_reduce_1D.sptl" "$FOLDER" -p G=$G -p S=$S -p K=$K
+run_twophase_reduce_1d() {
+    EXTRA_ARGS=$@
+    echo "--- twophase_reduce_1d G=$G S=$S K=$K $EXTRA_ARGS ---"
+    sptlc "$COLLECTIVES_DIR/twophase_reduce_1D.sptl" "$FOLDER" -p G=$G -p S=$S -p K=$K $EXTRA_ARGS
 
-python3 - <<PYEOF
+    python3 - <<PYEOF
 import numpy as np
 n_pes = $G * $S
 a = np.random.rand(n_pes, 1, $K).astype(np.float32)
 np.save('a_in.npy', a)
 PYEOF
 
-timeout -s 9 120 cs_python "$RUNTIME_PY" "$FOLDER" a_in.npy --benchmark
+    timeout -s 9 120 cs_python "$RUNTIME_PY" "$FOLDER" a_in.npy --benchmark
 
-verify_reduce_sum
-cleanup "$FOLDER"
+    verify_reduce_sum
+    cleanup "$FOLDER"
+}
+
+run_twophase_reduce_1d
+run_twophase_reduce_1d --disable-copy-elision
+run_twophase_reduce_1d --disable-task-recycling
+run_twophase_reduce_1d --disable-task-fusion


### PR DESCRIPTION
Adds a compiler flag

--disable-copy-elision

to disable copy elimination pass.

This is needed for the ablation study