### PR TITLE
Revert phase inlining change and test stencil lowering

### DIFF
--- a/spatialstencil/syntax/spatial_ir/canonicalization.py
+++ b/spatialstencil/syntax/spatial_ir/canonicalization.py
@@ -126,91 +126,6 @@ def canonicalize_phases(kernel: spir.Kernel) -> spir.Kernel:
     return spir.Kernel(kernel.name, kernel.parameters, kernel.arguments, new_body)
 
 
-def _register_identifier(used_versions: dict[str, set[int]], identifier: spir.Identifier) -> None:
-    used_versions[identifier.name].add(identifier.version)
-
-
-def _register_block_variables(used_versions: dict[str, set[int]], variables: list[spir.TypedIdentifier]) -> None:
-    for variable in variables:
-        _register_identifier(used_versions, variable.identifier)
-
-
-def _make_fresh_identifier(used_versions: dict[str, set[int]], identifier: spir.Identifier) -> spir.Identifier:
-    version = 0
-    while version in used_versions[identifier.name]:
-        version += 1
-
-    fresh_identifier = spir.Identifier(identifier.name, version)
-    fresh_identifier.lineinfo = getattr(identifier, 'lineinfo', None)
-    return fresh_identifier
-
-
-def _apply_identifier_replacements(
-        nodes: list[spir.SpatialNode], replacements: dict[spir.Identifier, spir.Identifier]) -> list[spir.SpatialNode]:
-    if not replacements:
-        return [copy.deepcopy(node) for node in nodes]
-
-    replacer = passes.FindAndReplace(replacements)
-    return [replacer.visit(copy.deepcopy(node)) for node in nodes]
-
-
-def _rewrite_place_declarations(
-        statements: list[spir.FieldDeclaration],
-        used_versions: dict[str, set[int]],
-        shared_identifiers: set[spir.Identifier],
-        existing_statements: list[spir.FieldDeclaration],
-        mark_appended_shared: bool = False,
-) -> tuple[dict[spir.Identifier, spir.Identifier], list[spir.FieldDeclaration], set[spir.Identifier]]:
-    replacements: dict[spir.Identifier, spir.Identifier] = {}
-    appended_statements: list[spir.FieldDeclaration] = []
-    appended_shared: set[spir.Identifier] = set()
-    shared_lookup = {
-        statement.field_name: statement.field_name
-        for statement in existing_statements
-        if statement.field_name in shared_identifiers
-    }
-
-    for statement in statements:
-        field_name = statement.field_name
-        if field_name in shared_lookup:
-            replacements[field_name] = copy.deepcopy(shared_lookup[field_name])
-            continue
-
-        rewritten_statement = copy.deepcopy(statement)
-        if field_name.version in used_versions[field_name.name]:
-            fresh_identifier = _make_fresh_identifier(used_versions, field_name)
-            replacements[field_name] = copy.deepcopy(fresh_identifier)
-            rewritten_statement.field_name = fresh_identifier
-
-        _register_identifier(used_versions, rewritten_statement.field_name)
-        appended_statements.append(rewritten_statement)
-        if mark_appended_shared:
-            appended_shared.add(rewritten_statement.field_name)
-
-    return replacements, appended_statements, appended_shared
-
-
-def _rewrite_stream_declarations(
-        statements: list[spir.StreamDeclaration],
-        used_versions: dict[str, set[int]],
-) -> tuple[dict[spir.Identifier, spir.Identifier], list[spir.StreamDeclaration]]:
-    replacements: dict[spir.Identifier, spir.Identifier] = {}
-    appended_statements: list[spir.StreamDeclaration] = []
-
-    for statement in statements:
-        stream_name = statement.stream_name
-        rewritten_statement = copy.deepcopy(statement)
-        if stream_name.version in used_versions[stream_name.name]:
-            fresh_identifier = _make_fresh_identifier(used_versions, stream_name)
-            replacements[stream_name] = copy.deepcopy(fresh_identifier)
-            rewritten_statement.stream_name = fresh_identifier
-
-        _register_identifier(used_versions, rewritten_statement.stream_name)
-        appended_statements.append(rewritten_statement)
-
-    return replacements, appended_statements
-
-
 def inline_phases(kernel: spir.Kernel) -> spir.Kernel:
     """
     Inlines phases into their constituent computation and dataflow blocks by adding waits and appending all streams,
@@ -219,94 +134,53 @@ def inline_phases(kernel: spir.Kernel) -> spir.Kernel:
     rect_place: dict[tuple[int, int, int, int], spir.PlaceBlock] = {}
     rect_dataflow: dict[tuple[int, int, int, int], spir.DataflowBlock] = {}
     rect_compute: dict[tuple[int, int, int, int], spir.ComputeBlock] = {}
-    used_versions: dict[str, set[int]] = defaultdict(set)
-    shared_place_identifiers: dict[tuple[int, int, int, int], set[spir.Identifier]] = defaultdict(set)
-
     # After canonicalize phases, kernel body can only contain phases or place blocks
     for block in kernel.body:
         rect = block.get_grid_rect()
         if isinstance(block, spir.PlaceBlock):
             if rect in rect_place:
-                _, statements, shared_ids = _rewrite_place_declarations(
-                    block.statements,
-                    used_versions,
-                    shared_place_identifiers[rect],
-                    rect_place[rect].statements,
-                    mark_appended_shared=True,
-                )
-                rect_place[rect].statements.extend(statements)
-                shared_place_identifiers[rect].update(shared_ids)
+                rect_place[rect].statements.extend(block.statements)
             else:
                 rect_place[rect] = copy.deepcopy(block)
-                _register_block_variables(used_versions, rect_place[rect].variables)
-                for statement in rect_place[rect].statements:
-                    _register_identifier(used_versions, statement.field_name)
-                    shared_place_identifiers[rect].add(statement.field_name)
         elif isinstance(block, spir.Phase):
-            phase_replacements: dict[tuple[int, int, int, int], dict[spir.Identifier, spir.Identifier]] = defaultdict(dict)
-
             # Extend place blocks
             for place in block.place:
                 rect = place.get_grid_rect()
                 if rect in rect_place:
-                    phase_replacements[rect].update({
+                    # Replace variables in place statements with the new variables
+                    rep = passes.FindAndReplace({
                         oldv.identifier: newv.identifier
                         for oldv, newv in zip(place.variables, rect_place[rect].variables)
                     })
-
-                    replacements, statements, _ = _rewrite_place_declarations(
-                        place.statements,
-                        used_versions,
-                        shared_place_identifiers[rect],
-                        rect_place[rect].statements,
-                    )
-                    phase_replacements[rect].update(replacements)
-                    rect_place[rect].statements.extend(statements)
+                    stmts = [rep.visit(s) for s in place.statements]
+                    rect_place[rect].statements.extend(stmts)
                 else:
                     rect_place[rect] = copy.deepcopy(place)
-                    _register_block_variables(used_versions, rect_place[rect].variables)
-                    for statement in rect_place[rect].statements:
-                        _register_identifier(used_versions, statement.field_name)
-
             # Extend dataflow blocks
             for df in block.dataflow:
                 rect = df.get_grid_rect()
                 if rect in rect_dataflow:
-                    replacements = dict(phase_replacements[rect])
-                    replacements.update({
+                    rep = passes.FindAndReplace({
                         oldv.identifier: newv.identifier
                         for oldv, newv in zip(df.variables, rect_dataflow[rect].variables)
                     })
-
-                    stream_replacements, statements = _rewrite_stream_declarations(df.statements, used_versions)
-                    phase_replacements[rect].update(stream_replacements)
-                    rect_dataflow[rect].statements.extend(_apply_identifier_replacements(statements, replacements))
+                    stmts = [rep.visit(s) for s in df.statements]
+                    rect_dataflow[rect].statements.extend(stmts)
                 else:
                     rect_dataflow[rect] = copy.deepcopy(df)
-                    _register_block_variables(used_versions, rect_dataflow[rect].variables)
-                    statements = _apply_identifier_replacements(
-                        rect_dataflow[rect].statements, phase_replacements[rect])
-                    rect_dataflow[rect].statements = []
-                    stream_replacements, rewritten_statements = _rewrite_stream_declarations(statements, used_versions)
-                    phase_replacements[rect].update(stream_replacements)
-                    rect_dataflow[rect].statements.extend(rewritten_statements)
-
             # Concatenate compute blocks with an endphase statement
             for compute in block.compute:
                 rect = compute.get_grid_rect()
                 if rect in rect_compute:
                     rect_compute[rect].statements.append(spir.AwaitAllStatement())
-                    replacements = dict(phase_replacements[rect])
-                    replacements.update({
+                    rep = passes.FindAndReplace({
                         oldv.identifier: newv.identifier
                         for oldv, newv in zip(compute.variables, rect_compute[rect].variables)
                     })
-                    rect_compute[rect].statements.extend(_apply_identifier_replacements(compute.statements, replacements))
+                    stmts = [rep.visit(s) for s in compute.statements]
+                    rect_compute[rect].statements.extend(stmts)
                 else:
                     rect_compute[rect] = copy.deepcopy(compute)
-                    _register_block_variables(used_versions, rect_compute[rect].variables)
-                    rect_compute[rect].statements = _apply_identifier_replacements(
-                        rect_compute[rect].statements, phase_replacements[rect])
         else:
             raise TypeError(f'Unexpected block type "{type(block).__name__}" in kernel. Was ``canonicalize_phases`` '
                             'called?')

--- a/spatialstencil/syntax/spatial_ir/irnodes.py
+++ b/spatialstencil/syntax/spatial_ir/irnodes.py
@@ -459,10 +459,12 @@ class SubgridExpression(SpatialNode):
             raise TypeError(f'Cannot obtain concrete grid size. y range value "{stop_y.as_ir()}" is not integral')
 
         x_stride, y_stride = self.get_grid_stride()
+
         # Canonicalize: round stop up to the next stride boundary relative to start.
         def _canon(start, stop, stride):
             offset = stop - start
             return start + ((offset + stride - 1) // stride) * stride
+
         return start_x, _canon(start_x, stop_x, x_stride), start_y, _canon(start_y, stop_y, y_stride)
 
     def get_grid_stride(self) -> tuple[int, int]:
@@ -599,10 +601,8 @@ class RoutingDeclaration(SpatialNode):
             return self.channel
         val = self.channel.eval()
         if not isinstance(val, int):
-            raise ValueError(
-                f"Channel expression '{self.channel.as_ir()}' did not evaluate to an integer. "
-                "Ensure all parameters and loop variables are concretized before CSL lowering."
-            )
+            raise ValueError(f"Channel expression '{self.channel.as_ir()}' did not evaluate to an integer. "
+                             "Ensure all parameters and loop variables are concretized before CSL lowering.")
         return val
 
     def as_ir(self, indent: int = 0) -> str:
@@ -736,11 +736,19 @@ class StreamDeclaration(SpatialNode):
     def validate(self) -> None:
         assert isinstance(self.dtype, StreamType)
         assert isinstance(self.stream_name, Identifier)
-        assert isinstance(self.stream, (RelativeStreamDeclaration, MulticastRangeStreamDeclaration, ExternStreamDeclaration))
+        assert isinstance(self.stream,
+                          (RelativeStreamDeclaration, MulticastRangeStreamDeclaration, ExternStreamDeclaration))
 
     def as_ir(self, indent: int = 0) -> str:
         indent_str = '  ' * indent
-        return f'{indent_str}stream<{self.dtype.element_type.as_ir()}> {self.stream_name.as_ir()} = {self.stream.as_ir()}'
+
+        # Properly indent stream contents
+        inner_stream = self.stream.as_ir()
+        inner_stream_lines = inner_stream.splitlines()
+        inner_stream = '\n'.join([inner_stream_lines[0]] +
+                                 [indent_str + line for line in inner_stream_lines[1:]])
+
+        return f'{indent_str}stream<{self.dtype.element_type.as_ir()}> {self.stream_name.as_ir()} = {inner_stream}'
 
 
 ###
@@ -1395,9 +1403,9 @@ class Kernel(SpatialNode):
         phase_id = 1
         for elem in self.body:
             if isinstance(elem, Phase):
-                rectangles.extend([r for a in elem.place     if (r := _make_rect(a, phase_id)) is not None])
-                rectangles.extend([r for a in elem.dataflow  if (r := _make_rect(a, phase_id)) is not None])
-                rectangles.extend([r for a in elem.compute   if (r := _make_rect(a, phase_id)) is not None])
+                rectangles.extend([r for a in elem.place if (r := _make_rect(a, phase_id)) is not None])
+                rectangles.extend([r for a in elem.dataflow if (r := _make_rect(a, phase_id)) is not None])
+                rectangles.extend([r for a in elem.compute if (r := _make_rect(a, phase_id)) is not None])
                 phase_id += 1
             else:
                 assert isinstance(elem, (ComputeBlock, DataflowBlock, PlaceBlock))

--- a/tests/csl_runtime/test_benchmarks.sh
+++ b/tests/csl_runtime/test_benchmarks.sh
@@ -9,6 +9,7 @@ BLUE='\033[0;34m'
 NC='\033[0m'
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+STENCIL_DIR="$SCRIPT_DIR/../../samples"
 BENCHMARK_DIR="$SCRIPT_DIR/../../samples/benchmarks"
 RUNTIME="$SCRIPT_DIR/../../spatialstencil/runtime/runtime.py"
 OUTPUT_DIR="$SCRIPT_DIR/benchmark"
@@ -17,6 +18,13 @@ TOTAL=0
 PASSED=0
 FAILED=0
 FAILED_TESTS=()
+
+echo -e "${BLUE}================================${NC}"
+echo -e "${BLUE}  Generating SPADA files${NC}"
+echo -e "${BLUE}================================${NC}"
+echo ""
+
+python -m spatialstencil.cli.gt4py_to_spatial "$STENCIL_DIR/stencils.py" 4,4,4 "$BENCHMARK_DIR"
 
 echo -e "${BLUE}================================${NC}"
 echo -e "${BLUE}  Running Benchmark Suite${NC}"


### PR DESCRIPTION
* Reverts unique stream names during phase inlining, which caused generating too many channels
* `test_benchmarks.sh` now regenerates the .sptl files every time
* Stream indentation has been corrected (generated .sptl files have no diff with repository)
