### PR TITLE
Implement Cerebras Appliance Mode compiler and runtime entry points

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,11 @@ setup(
         ],
     },
     entry_points={
-        "console_scripts": ["sptlc=spada.cli.compiler:compile_spatial_ir"],
+        "console_scripts": [
+            "sptlc=spada.cli.compiler:compile_spatial_ir",
+            "sptlc-appliance=spada.cli.appliance_compiler:compile_spatial_ir_appliance",
+            "spada-wse-launcher=spada.runtime.appliance_launcher:launch",
+        ],
     },
     include_package_data=True,
     package_data={

--- a/spada/cli/appliance_compiler.py
+++ b/spada/cli/appliance_compiler.py
@@ -1,0 +1,157 @@
+"""
+Appliance-mode Spatial IR compiler (``sptlc-appliance``).
+
+Unlike :mod:`spada.cli.compiler`, which invokes ``cslc`` locally inside the containerized SDK, this
+frontend dispatches the CSL compilation to a worker node on a Cerebras Wafer-Scale Cluster through
+``cerebras.sdk.client.SdkCompiler``. See https://sdk.cerebras.ai/appliance-mode for details.
+
+The generated CSL sources and ``metadata.json`` are identical to the ones produced by ``sptlc``; the
+only additional output is ``artifact_path.json``, which records the compiled artifact returned by
+the appliance so that :mod:`spada.runtime.appliance_launcher` (``spada-wse-launcher``) can run it.
+
+This module is intentionally *not* imported anywhere else in the package, so that ``cerebras_sdk``
+and ``cerebras_appliance`` remain optional dependencies of SpaDA.
+"""
+import click
+import json
+import os
+from typing import Any, Optional
+
+from spada.cli.compiler import codegen_options, cslc_arguments, generate_program
+
+#: Name of the file recording the appliance artifact, written into the output folder.
+ARTIFACT_INFO_FILE = 'artifact_path.json'
+
+#: Directory (relative to the artifact root) that ``cslc`` writes the compiled ELFs into. It must
+#: stay in sync with ``spada.runtime.runtime.Program``, which looks for ``<folder>/out``.
+ARTIFACT_OUTPUT_DIR = 'out'
+
+
+def _import_sdk_compiler():
+    """Import ``SdkCompiler`` lazily, with an actionable error message if the SDK is missing."""
+    try:
+        from cerebras.sdk.client import SdkCompiler
+    except (ImportError, ModuleNotFoundError) as e:
+        raise ImportError(
+            "The Cerebras appliance client was not found. `sptlc-appliance` requires the appliance "
+            "packages (cerebras_sdk and cerebras_appliance) to be installed in the current "
+            "environment. Use plain `sptlc` for containerized (non-appliance) compilation.") from e
+    return SdkCompiler
+
+
+def compile_on_appliance(program, hardware_fabric: Optional[bool] = None, mgmt_namespace: Optional[str] = None,
+                         resource_cpu: Optional[int] = None, resource_mem: Optional[int] = None,
+                         disable_version_check: bool = True) -> str:
+    """
+    Compile an already-generated program on the appliance and return the resulting artifact path.
+
+    :param program: The :class:`~spada.cli.compiler.GeneratedProgram` to compile.
+    :param hardware_fabric: Compile for the full hardware fabric rather than the tight kernel
+                            rectangle. Defaults to whether ``CM_ADDR`` is set in the environment.
+    :param mgmt_namespace: Appliance cluster namespace (defaults to the cluster's default).
+    :param resource_cpu: CPU cores for the compile job, in units of 1/1000.
+    :param resource_mem: Memory for the compile job, in bytes.
+    :param disable_version_check: Ignore version differences between client and appliance.
+    :return: The path of the compile artifact on the appliance.
+    """
+    SdkCompiler = _import_sdk_compiler()
+
+    compile_args = ' '.join(cslc_arguments(program, hardware_fabric=hardware_fabric) +
+                            ['-o', ARTIFACT_OUTPUT_DIR])
+
+    kwargs: dict[str, Any] = {'disable_version_check': disable_version_check}
+    if mgmt_namespace is not None:
+        kwargs['mgmt_namespace'] = mgmt_namespace
+    if resource_cpu is not None:
+        kwargs['resource_cpu'] = resource_cpu
+    if resource_mem is not None:
+        kwargs['resource_mem'] = resource_mem
+
+    print("Compiling on the appliance with arguments:", compile_args)
+    with SdkCompiler(**kwargs) as compiler:
+        artifact_path = compiler.compile(program.output_folder, 'layout.csl', compile_args, program.output_folder)
+
+    return artifact_path
+
+
+@click.command()
+@click.argument('input_file', type=click.Path(exists=True, dir_okay=False))
+@click.argument('output_folder', type=click.Path(dir_okay=True))
+@codegen_options
+@click.option('--generate-only', '-g', is_flag=True,
+              help='Only generate the output files without compiling them on the appliance')
+@click.option('--simulator', 'simulator', is_flag=True,
+              help='Target the appliance simulator: compile for the tight kernel rectangle instead '
+                   'of the full hardware fabric, and default the launcher to simulator mode')
+@click.option('--mgmt-namespace', default=None, type=str, help='Appliance cluster namespace')
+@click.option('--resource-cpu', default=None, type=int, help='CPU cores for the compile job (units of 1/1000)')
+@click.option('--resource-mem', default=None, type=int, help='Memory for the compile job, in bytes')
+@click.option('--check-version/--disable-version-check', 'check_version', default=False,
+              help='Whether to enforce a matching client/appliance SDK version (default: do not)')
+def compile_spatial_ir_appliance(input_file: str, output_folder: str, param: list[str], offset_x: int, offset_y: int,
+                                 generate_only: bool, simulator: bool, mgmt_namespace: Optional[str],
+                                 resource_cpu: Optional[int], resource_mem: Optional[int], check_version: bool,
+                                 disable_benchmarking: bool, disable_asynchronous: bool, disable_dsd: bool,
+                                 disable_map: bool, disable_task_fusion: bool, disable_task_recycling: bool,
+                                 disable_copy_elision: bool, disable_close_elision: bool, disable_switching: bool):
+    program = generate_program(
+        input_file,
+        output_folder,
+        param=param,
+        offset_x=offset_x,
+        offset_y=offset_y,
+        disable_benchmarking=disable_benchmarking,
+        disable_asynchronous=disable_asynchronous,
+        disable_dsd=disable_dsd,
+        disable_map=disable_map,
+        disable_task_fusion=disable_task_fusion,
+        disable_task_recycling=disable_task_recycling,
+        disable_copy_elision=disable_copy_elision,
+        disable_close_elision=disable_close_elision,
+        disable_switching=disable_switching,
+    )
+
+    if generate_only:
+        print("Generated output files without compiling.")
+        return
+
+    # On real hardware the program must be compiled for the whole fabric; only the simulator can use
+    # the tight kernel rectangle.
+    hardware_fabric = not simulator
+
+    try:
+        artifact_path = compile_on_appliance(
+            program,
+            hardware_fabric=hardware_fabric,
+            mgmt_namespace=mgmt_namespace,
+            resource_cpu=resource_cpu,
+            resource_mem=resource_mem,
+            disable_version_check=not check_version,
+        )
+    except ImportError as e:
+        print(f"\033[91m{e}\033[0m")
+        exit(1)
+    except Exception as e:
+        print(f"\033[91mAppliance compilation failed with error:\033[0m {e}")
+        exit(1)
+
+    artifact_info = {
+        'artifact_path': artifact_path,
+        'simulator': simulator,
+        'kernel_name': program.metadata['kernel_name'],
+        'mgmt_namespace': mgmt_namespace,
+    }
+    info_path = os.path.join(output_folder, ARTIFACT_INFO_FILE)
+    with open(info_path, 'w', encoding='utf8') as f:
+        json.dump(artifact_info, f, indent=2)
+
+    print(f"\033[92mAppliance compilation successful.\033[0m Artifact: {artifact_path}")
+    print(f"Artifact recorded in {info_path}.")
+    print("To run the program, use the SpaDA appliance launcher with npy files as arguments:")
+    args_str = ' '.join(f"{arg}.npy" for arg in program.metadata["argument_order"] if arg in program.input_args)
+    simulator_flag = ' --simulator' if simulator else ''
+    print(f"spada-wse-launcher {output_folder} {args_str}{simulator_flag}")
+
+
+if __name__ == '__main__':
+    compile_spatial_ir_appliance()

--- a/spada/cli/compiler.py
+++ b/spada/cli/compiler.py
@@ -1,6 +1,8 @@
 import click
 import itertools
 import os
+from dataclasses import dataclass
+from typing import Any, Optional
 from spada.lowering import spatial_ir_to_csl as s2c
 from spada.syntax.spatial_ir import parser, passes, analysis, irnodes as spa, canonicalization
 from spada.syntax.csl import constants as csl
@@ -8,29 +10,33 @@ from spada.syntax.common import serialization
 import subprocess
 
 
-@click.command()
-@click.argument('input_file', type=click.Path(exists=True, dir_okay=False))
-@click.argument('output_folder', type=click.Path(dir_okay=True))
-@click.option('--param', '-p', multiple=True, help='Kernel parameters in key=value format')
-@click.option('--offset-x', '-x', default=0, type=int, help='Offset for rectangular region in x direction')
-@click.option('--offset-y', '-y', default=0, type=int, help='Offset for rectangular region in y direction')
-@click.option('--generate-only', '-g', is_flag=True, help='Only generate the output files without compiling them')
-@click.option('--disable-benchmarking', is_flag=True, help='Disable benchmarking code generation (and memory overhead)')
-@click.option('--disable-asynchronous', is_flag=True, help='Disable asynchronous task code generation')
-@click.option('--disable-dsd', is_flag=True, help='Disable DSD operation detection and code generation')
-@click.option('--disable-map', is_flag=True, help='Disable @map operation detection and code generation')
-@click.option('--disable-task-fusion', is_flag=True, help='Disable task fusion optimization')
-@click.option('--disable-task-recycling', is_flag=True, help='Disable task ID recycling')
-@click.option('--disable-copy-elision', is_flag=True, help='Disable copy elimination optimization pass')
-@click.option('--disable-close-elision', is_flag=True, help='Disable elision of unnecessary stream closes')
-@click.option('--disable-switching', is_flag=True, help='Disable router switch positions for shared channels')
-def compile_spatial_ir(input_file: str, output_folder: str, param: list[str], offset_x: int, offset_y: int,
-                       generate_only: bool, disable_benchmarking: bool,
-                       disable_asynchronous: bool, disable_dsd: bool, disable_map: bool,
-                       disable_task_fusion: bool, disable_task_recycling: bool, disable_copy_elision: bool,
-                       disable_close_elision: bool, disable_switching: bool):
-    # Parse parameters into dictionary
-    kernel_parameters = {}
+@dataclass
+class GeneratedProgram:
+    """
+    The result of generating CSL sources and ``metadata.json`` for a Spatial IR kernel.
+
+    This is the hand-off point between the code generator and whichever backend actually invokes
+    the CSL compiler (``cslc`` directly in :func:`compile_spatial_ir`, or the appliance-mode
+    ``SdkCompiler`` in ``spada.cli.appliance_compiler``).
+    """
+    output_folder: str
+    metadata: dict[str, Any]
+    input_args: dict[str, Any]
+    output_args: dict[str, Any]
+    #: Tight fabric extent (xend, yend), i.e. the last used PE + 1, including the memcpy columns/rows
+    fabric_extent: tuple[int, int]
+    #: Value to pass to ``--fabric-offsets``
+    fabric_offsets: tuple[int, int]
+    #: Value to pass to ``--channels``
+    memcpy_channels: int
+
+
+def parse_parameters(param: list[str]) -> dict[str, Any]:
+    """
+    Parse ``key=value`` kernel parameters from the command line into a dictionary, converting the
+    values to integers or floats where possible.
+    """
+    kernel_parameters: dict[str, Any] = {}
     for p in param:
         if '=' not in p:
             raise ValueError(f'Invalid parameter format: {p}. Expected key=value')
@@ -43,6 +49,43 @@ def compile_spatial_ir(input_file: str, output_folder: str, param: list[str], of
                 kernel_parameters[key] = float(value)
             except ValueError:
                 kernel_parameters[key] = value
+    return kernel_parameters
+
+
+def codegen_options(func):
+    """Click options shared by every Spatial IR compiler frontend."""
+    options = [
+        click.option('--param', '-p', multiple=True, help='Kernel parameters in key=value format'),
+        click.option('--offset-x', '-x', default=0, type=int, help='Offset for rectangular region in x direction'),
+        click.option('--offset-y', '-y', default=0, type=int, help='Offset for rectangular region in y direction'),
+        click.option('--disable-benchmarking', is_flag=True,
+                     help='Disable benchmarking code generation (and memory overhead)'),
+        click.option('--disable-asynchronous', is_flag=True, help='Disable asynchronous task code generation'),
+        click.option('--disable-dsd', is_flag=True, help='Disable DSD operation detection and code generation'),
+        click.option('--disable-map', is_flag=True, help='Disable @map operation detection and code generation'),
+        click.option('--disable-task-fusion', is_flag=True, help='Disable task fusion optimization'),
+        click.option('--disable-task-recycling', is_flag=True, help='Disable task ID recycling'),
+        click.option('--disable-copy-elision', is_flag=True, help='Disable copy elimination optimization pass'),
+        click.option('--disable-close-elision', is_flag=True, help='Disable elision of unnecessary stream closes'),
+        click.option('--disable-switching', is_flag=True, help='Disable router switch positions for shared channels'),
+    ]
+    for option in reversed(options):
+        func = option(func)
+    return func
+
+
+def generate_program(input_file: str, output_folder: str, param: list[str] = (), offset_x: int = 0, offset_y: int = 0,
+                     disable_benchmarking: bool = False, disable_asynchronous: bool = False, disable_dsd: bool = False,
+                     disable_map: bool = False, disable_task_fusion: bool = False,
+                     disable_task_recycling: bool = False, disable_copy_elision: bool = False,
+                     disable_close_elision: bool = False, disable_switching: bool = False) -> GeneratedProgram:
+    """
+    Lower a Spatial IR file to CSL and write the sources plus ``metadata.json`` into ``output_folder``.
+
+    No CSL compiler is invoked here; the returned :class:`GeneratedProgram` carries everything a
+    backend needs in order to do so.
+    """
+    kernel_parameters = parse_parameters(param)
 
     kernel = parser.parse_file(input_file)
     # If there are unconcretized parameters, we need to concretize them
@@ -112,9 +155,8 @@ def compile_spatial_ir(input_file: str, output_folder: str, param: list[str], of
         with open(output_path, 'w') as out_file:
             out_file.write(f.code)
 
-    # Compile the generated CSL files using the cslc command (and change the cwd to the output folder)
-    # Get the fabric dimensions from the kernel and offsets from the command line arguments
-    # Command: cslc layout.csl --fabric-dims=16,16 --fabric-offsets=0,0 --memcpy --channels=1
+    # Compute the arguments the generated code must be compiled with, e.g.,
+    # cslc layout.csl --fabric-dims=16,16 --fabric-offsets=0,0 --memcpy --channels=1
     memcpy_channels = 1  # TODO: Determine the number of memcpy channels (1-16) based on the kernel arguments
 
     # Generate metadata.json file
@@ -172,19 +214,74 @@ def compile_spatial_ir(input_file: str, output_folder: str, param: list[str], of
     }
     serialization.save_to_json(metadata, os.path.join(output_folder, 'metadata.json'))
 
+    return GeneratedProgram(
+        output_folder=output_folder,
+        metadata=metadata,
+        input_args=input_args,
+        output_args=output_args,
+        fabric_extent=(xend, yend),
+        fabric_offsets=(offset_x + xbegin, offset_y + ybegin),
+        memcpy_channels=memcpy_channels,
+    )
+
+
+def cslc_arguments(program: GeneratedProgram, hardware_fabric: Optional[bool] = None) -> list[str]:
+    """
+    Compute the ``cslc`` flags (everything but the executable and the top-level file) for a
+    generated program.
+
+    :param program: The generated program to compile.
+    :param hardware_fabric: If True, compile for the full hardware fabric dimensions instead of the
+                            tight kernel rectangle. Defaults to whether ``CM_ADDR`` is set.
+    """
+    if hardware_fabric is None:
+        hardware_fabric = 'CM_ADDR' in os.environ
+
+    if hardware_fabric:
+        fabric_width, fabric_height = csl.HARDWARE_FABRIC_DIMS
+    else:
+        fabric_width, fabric_height = program.fabric_extent
+
+    return [
+        f'--arch={csl.ARCH}', f'--fabric-dims={fabric_width},{fabric_height}',
+        f'--fabric-offsets={program.fabric_offsets[0]},{program.fabric_offsets[1]}', '--memcpy',
+        f'--channels={program.memcpy_channels}'
+    ]
+
+
+@click.command()
+@click.argument('input_file', type=click.Path(exists=True, dir_okay=False))
+@click.argument('output_folder', type=click.Path(dir_okay=True))
+@codegen_options
+@click.option('--generate-only', '-g', is_flag=True, help='Only generate the output files without compiling them')
+def compile_spatial_ir(input_file: str, output_folder: str, param: list[str], offset_x: int, offset_y: int,
+                       generate_only: bool, disable_benchmarking: bool,
+                       disable_asynchronous: bool, disable_dsd: bool, disable_map: bool,
+                       disable_task_fusion: bool, disable_task_recycling: bool, disable_copy_elision: bool,
+                       disable_close_elision: bool, disable_switching: bool):
+    program = generate_program(
+        input_file,
+        output_folder,
+        param=param,
+        offset_x=offset_x,
+        offset_y=offset_y,
+        disable_benchmarking=disable_benchmarking,
+        disable_asynchronous=disable_asynchronous,
+        disable_dsd=disable_dsd,
+        disable_map=disable_map,
+        disable_task_fusion=disable_task_fusion,
+        disable_task_recycling=disable_task_recycling,
+        disable_copy_elision=disable_copy_elision,
+        disable_close_elision=disable_close_elision,
+        disable_switching=disable_switching,
+    )
+
     if generate_only:
         print("Generated output files without compiling.")
         return
 
-    if 'CM_ADDR' in os.environ:
-        fabric_width, fabric_height = csl.HARDWARE_FABRIC_DIMS
-    else:
-        fabric_width, fabric_height = xend, yend
-
-    cslc_command = [
-        os.getenv('CSLC', 'cslc'), f'--arch={csl.ARCH}', 'layout.csl', f'--fabric-dims={fabric_width},{fabric_height}',
-        f'--fabric-offsets={offset_x + xbegin},{offset_y + ybegin}', '--memcpy', f'--channels={memcpy_channels}'
-    ]
+    # Compile the generated CSL files using the cslc command (and change the cwd to the output folder)
+    cslc_command = [os.getenv('CSLC', 'cslc'), 'layout.csl'] + cslc_arguments(program)
     print("Compiling with command:", ' '.join(cslc_command))
     try:
         subprocess.run(cslc_command, cwd=output_folder, check=True)
@@ -195,7 +292,7 @@ def compile_spatial_ir(input_file: str, output_folder: str, param: list[str], of
     print("\033[92mCompilation successful.\033[0m "
           "To run the program, use the Cerebras SDK python runtime with npy files as arguments:")
     runtime_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "runtime", "runtime.py"))
-    args_str = ' '.join(f"{arg}.npy" for arg in metadata["argument_order"] if arg in input_args)
+    args_str = ' '.join(f"{arg}.npy" for arg in program.metadata["argument_order"] if arg in program.input_args)
     cs_python = os.getenv('CS_PYTHON', 'cs_python')
     print(f"{cs_python} {runtime_path} {output_folder} {args_str}")
 

--- a/spada/lowering/spatial_ir_to_csl.py
+++ b/spada/lowering/spatial_ir_to_csl.py
@@ -328,7 +328,7 @@ def generate_rectangle(kernel: spir.Kernel,
         dsd_ops.DISABLE_DSD = True
 
     header.write("""
-param memcpy_params: comptime_struct;
+param memcpy_params;
 const sys_mod = @import_module("<memcpy/memcpy>", memcpy_params);
 """)
 

--- a/spada/runtime/appliance_launcher.py
+++ b/spada/runtime/appliance_launcher.py
@@ -1,0 +1,306 @@
+"""
+Appliance-mode equivalent of :mod:`spada.runtime.runtime` (``spada-wse-launcher``).
+
+In appliance mode the host program cannot talk to the wafer directly: it has to run on a worker node
+inside the Cerebras Wafer-Scale Cluster. ``cerebras.sdk.client.SdkLauncher`` does that -- it unpacks
+the compile artifact produced by ``sptlc-appliance`` on a worker node, stages extra files next to it,
+and runs shell commands there (see https://sdk.cerebras.ai/appliance-mode).
+
+This module therefore does not reimplement the memcpy logic. It stages the regular SpaDA runtime
+(``spada/runtime/runtime.py``), the program's ``metadata.json`` and the input ``.npy`` files onto the
+worker node, runs
+
+    cs_python runtime.py . <inputs...> --cm-addr %CMADDR%
+
+there, and downloads the resulting ``OUT_*.npy`` files back to the local machine.
+
+Like :mod:`spada.cli.appliance_compiler`, this module is never imported by the rest of SpaDA, so the
+appliance packages (``cerebras_sdk``, ``cerebras_appliance``) stay optional dependencies.
+"""
+import click
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+#: Name of the file written by ``sptlc-appliance`` that records the compile artifact.
+ARTIFACT_INFO_FILE = "artifact_path.json"
+
+#: Name the SpaDA runtime is staged under on the worker node.
+REMOTE_RUNTIME_SCRIPT = "runtime.py"
+
+#: Working directory of the staged program on the worker node. The compile artifact unpacks the
+#: compiled ELFs into ``./out``, and ``metadata.json`` is staged next to it, which is exactly the
+#: layout ``spada.runtime.runtime.Program`` expects.
+REMOTE_PROGRAM_FOLDER = "."
+
+
+def _import_sdk_launcher():
+    """Import ``SdkLauncher`` lazily, with an actionable error message if the SDK is missing."""
+    try:
+        from cerebras.sdk.client import SdkLauncher
+    except (ImportError, ModuleNotFoundError) as e:
+        raise ImportError(
+            "The Cerebras appliance client was not found. `spada-wse-launcher` requires the "
+            "appliance packages (cerebras_sdk and cerebras_appliance) to be installed in the "
+            "current environment. Use `cs_python spada/runtime/runtime.py` for containerized "
+            "(non-appliance) execution.") from e
+    return SdkLauncher
+
+
+def local_runtime_script() -> str:
+    """Absolute path of the SpaDA runtime script that gets staged onto the worker node."""
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "runtime.py"))
+
+
+class ApplianceProgram:
+    """
+    A compiled SpaDA program that runs on a Cerebras Wafer-Scale Cluster through ``SdkLauncher``.
+
+    :param program_folder: Folder produced by ``sptlc-appliance`` (holds ``metadata.json`` and
+                           ``artifact_path.json``).
+    :param artifact_path: Compile artifact to run. Defaults to the one recorded in
+                          ``artifact_path.json``.
+    :param simulator: Run on the appliance simulator. Defaults to the value recorded at compile time.
+    :param output_dir: Local directory the outputs are downloaded into.
+    :param cs_python: Name of the ``cs_python`` executable on the worker node.
+    :param mgmt_namespace: Appliance cluster namespace (defaults to the cluster's default).
+    :param resource_cpu: CPU cores for the launcher job, in units of 1/1000.
+    :param resource_mem: Memory for the launcher job, in bytes.
+    :param disable_version_check: Ignore version differences between client and appliance.
+    """
+
+    def __init__(
+        self,
+        program_folder: str,
+        artifact_path: Optional[str] = None,
+        simulator: Optional[bool] = None,
+        output_dir: str = "",
+        cs_python: Optional[str] = None,
+        mgmt_namespace: Optional[str] = None,
+        resource_cpu: Optional[int] = None,
+        resource_mem: Optional[int] = None,
+        disable_version_check: bool = True,
+    ):
+        self.folder = Path(program_folder)
+        self.output_dir = Path(output_dir)
+        self.cs_python = cs_python or "cs_python"
+        self.disable_version_check = disable_version_check
+        self.resource_cpu = resource_cpu
+        self.resource_mem = resource_mem
+
+        self.metadata_path = self.folder / "metadata.json"
+        if not self.metadata_path.exists():
+            raise FileNotFoundError(f"Metadata file not found at {self.metadata_path}")
+        with open(self.metadata_path, "r", encoding="utf8") as f:
+            self.metadata: Dict[str, Any] = json.load(f)
+
+        artifact_info = self._load_artifact_info()
+        self.artifact_path = artifact_path or artifact_info.get("artifact_path")
+        if not self.artifact_path:
+            raise ValueError(
+                f"No compile artifact given and none recorded in {self.folder / ARTIFACT_INFO_FILE}. "
+                "Compile the program with `sptlc-appliance`, or pass --artifact-path explicitly.")
+        if simulator is None:
+            simulator = bool(artifact_info.get("simulator", False))
+        self.simulator = simulator
+        self.mgmt_namespace = mgmt_namespace if mgmt_namespace is not None else artifact_info.get("mgmt_namespace")
+
+        self.inputs: Dict[str, Any] = self.metadata.get("inputs", {})
+        self.outputs: Dict[str, Any] = self.metadata.get("outputs", {})
+
+    def _load_artifact_info(self) -> Dict[str, Any]:
+        info_path = self.folder / ARTIFACT_INFO_FILE
+        if not info_path.exists():
+            return {}
+        with open(info_path, "r", encoding="utf8") as f:
+            return json.load(f)
+
+    def _launcher_kwargs(self) -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {
+            "simulator": self.simulator,
+            "disable_version_check": self.disable_version_check,
+        }
+        if self.mgmt_namespace is not None:
+            kwargs["mgmt_namespace"] = self.mgmt_namespace
+        if self.resource_cpu is not None:
+            kwargs["resource_cpu"] = self.resource_cpu
+        if self.resource_mem is not None:
+            kwargs["resource_mem"] = self.resource_mem
+        return kwargs
+
+    def expected_output_files(self, benchmark: bool = False, repetitions: int = 1) -> List[str]:
+        """
+        Names of the files ``spada.runtime.runtime`` writes on the worker node, which are the ones
+        downloaded back after the run.
+        """
+        files = [f"OUT_{name}.npy" for name in self.outputs]
+        if benchmark:
+            if self.metadata.get("memcpy_mode", False):
+                # runtime.py saves one file per repetition, zero-padded to the repetition count.
+                num_digits = len(str(repetitions))
+                files += [f"perf_cycles_{i:0{num_digits}d}.npy" for i in range(repetitions)]
+            else:
+                files.append("perf_cycles.npy")
+        return files
+
+    def runtime_command(self, input_files: Sequence[str] = (), benchmark: bool = False, randomize: bool = False,
+                        repetitions: int = 1) -> str:
+        """Build the ``cs_python`` command line that is executed on the worker node."""
+        command = [self.cs_python, REMOTE_RUNTIME_SCRIPT, REMOTE_PROGRAM_FOLDER]
+        command += [os.path.basename(f) for f in input_files]
+        if benchmark:
+            command.append("--benchmark")
+        if randomize:
+            command.append("--randomize")
+        if repetitions != 1:
+            command += ["--repetitions", str(repetitions)]
+        # %CMADDR% is substituted by SdkLauncher with the address of the allocated system.
+        command += ["--cm-addr", "%CMADDR%"]
+        return " ".join(command)
+
+    def run(
+        self,
+        input_files: Sequence[str] = (),
+        benchmark: bool = False,
+        randomize: bool = False,
+        repetitions: int = 1,
+        stage_files: Sequence[str] = (),
+        download_files: Sequence[str] = (),
+        download_simlog: bool = False,
+        dry_run: bool = False,
+    ) -> List[Path]:
+        """
+        Run the program on the appliance and download its outputs.
+
+        :param input_files: Local ``.npy`` files to stage and pass to the runtime, in argument order.
+        :param benchmark: Run in benchmark mode and fetch the cycle counts.
+        :param randomize: Let the runtime generate random inputs instead of using ``input_files``.
+        :param repetitions: Number of times to rerun the kernel.
+        :param stage_files: Additional local files to stage next to the program.
+        :param download_files: Additional worker-node files to download after the run.
+        :param download_simlog: Also download ``sim.log`` (simulator runs only).
+        :param dry_run: Print what would be done, without allocating an appliance job.
+        :return: The list of downloaded local paths.
+        """
+        if not randomize:
+            expected_inputs = [name for name in self.metadata.get("argument_order", []) if name in self.inputs]
+            if len(input_files) != len(expected_inputs):
+                raise ValueError(f"Expected {len(expected_inputs)} input files "
+                                 f"({', '.join(expected_inputs)}), got {len(input_files)}")
+            for input_file in input_files:
+                if not os.path.exists(input_file):
+                    raise FileNotFoundError(f"Input file not found: {input_file}")
+        else:
+            input_files = ()
+
+        command = self.runtime_command(input_files, benchmark=benchmark, randomize=randomize, repetitions=repetitions)
+        staged = [local_runtime_script(), str(self.metadata_path)] + [str(f) for f in input_files]
+        staged += [str(f) for f in stage_files]
+        wanted = list(self.expected_output_files(benchmark, repetitions)) + [str(f) for f in download_files]
+        if download_simlog:
+            wanted.append("sim.log")
+
+        if dry_run:
+            print(f"Artifact:  {self.artifact_path}")
+            print(f"Simulator: {self.simulator}")
+            print("Staging:   " + ", ".join(staged))
+            print("Command:   " + command)
+            print("Download:  " + ", ".join(wanted))
+            return []
+
+        os.makedirs(self.output_dir, exist_ok=True)
+
+        SdkLauncher = _import_sdk_launcher()
+        downloaded: List[Path] = []
+        print(f"Allocating appliance job ({'simulator' if self.simulator else 'hardware'})...", flush=True)
+        with SdkLauncher(self.artifact_path, **self._launcher_kwargs()) as launcher:
+            for path in staged:
+                launcher.stage(path)
+
+            print(f"Running: {command}", flush=True)
+            response = launcher.run(command)
+            if response:
+                print(response, flush=True)
+
+            for name in wanted:
+                out_path = self.output_dir / os.path.basename(name)
+                try:
+                    launcher.download_artifact(name, str(out_path))
+                except Exception as e:  # Missing artifacts should not lose the ones that do exist
+                    print(f"\033[93mWarning:\033[0m could not download '{name}': {e}")
+                    continue
+                downloaded.append(out_path)
+
+        return downloaded
+
+
+@click.command()
+@click.argument('program_folder', type=click.Path(exists=True, file_okay=False))
+@click.argument('input_files', nargs=-1, type=click.Path(exists=True, dir_okay=False))
+@click.option('--simulator/--hardware', 'simulator', default=None,
+              help='Run on the appliance simulator or on hardware (default: as compiled)')
+@click.option('--artifact-path', default=None, type=str,
+              help=f'Compile artifact to run (default: the one recorded in {ARTIFACT_INFO_FILE})')
+@click.option('--benchmark', is_flag=True, help='Run in benchmark mode and fetch cycle counts')
+@click.option('--randomize', is_flag=True, help='Randomize input data on the worker node instead of staging files')
+@click.option('--repetitions', default=1, type=int, help='Number of repetitions to run')
+@click.option('--output-dir', default='', type=click.Path(file_okay=False), help='Local directory for the results')
+@click.option('--stage', 'stage_files', multiple=True, type=click.Path(exists=True),
+              help='Additional local file to stage on the worker node (repeatable)')
+@click.option('--download', 'download_files', multiple=True, type=str,
+              help='Additional worker-node file to download after the run (repeatable)')
+@click.option('--download-simlog', is_flag=True, help='Also download sim.log (simulator runs)')
+@click.option('--cs-python', default=None, type=str, help='Name of the cs_python executable on the worker node')
+@click.option('--mgmt-namespace', default=None, type=str, help='Appliance cluster namespace')
+@click.option('--resource-cpu', default=None, type=int, help='CPU cores for the launcher job (units of 1/1000)')
+@click.option('--resource-mem', default=None, type=int, help='Memory for the launcher job, in bytes')
+@click.option('--check-version/--disable-version-check', 'check_version', default=False,
+              help='Whether to enforce a matching client/appliance SDK version (default: do not)')
+@click.option('--dry-run', is_flag=True, help='Print the staging plan and command without running anything')
+def launch(program_folder: str, input_files: tuple, simulator: Optional[bool], artifact_path: Optional[str],
+           benchmark: bool, randomize: bool, repetitions: int, output_dir: str, stage_files: tuple,
+           download_files: tuple, download_simlog: bool, cs_python: Optional[str], mgmt_namespace: Optional[str],
+           resource_cpu: Optional[int], resource_mem: Optional[int], check_version: bool, dry_run: bool):
+    """Run a program compiled by `sptlc-appliance` on a Cerebras Wafer-Scale Cluster."""
+    program = ApplianceProgram(
+        program_folder,
+        artifact_path=artifact_path,
+        simulator=simulator,
+        output_dir=output_dir,
+        cs_python=cs_python,
+        mgmt_namespace=mgmt_namespace,
+        resource_cpu=resource_cpu,
+        resource_mem=resource_mem,
+        disable_version_check=not check_version,
+    )
+
+    try:
+        downloaded = program.run(
+            input_files=input_files,
+            benchmark=benchmark,
+            randomize=randomize,
+            repetitions=repetitions,
+            stage_files=stage_files,
+            download_files=download_files,
+            download_simlog=download_simlog,
+            dry_run=dry_run,
+        )
+    except ImportError as e:
+        print(f"\033[91m{e}\033[0m")
+        exit(1)
+
+    if dry_run:
+        return
+
+    if not downloaded:
+        print("\033[93mRun finished, but no output files were downloaded.\033[0m")
+        return
+
+    print("\033[92mRun complete.\033[0m Results:")
+    for path in downloaded:
+        print(f"  {path}")
+
+
+if __name__ == '__main__':
+    launch()

--- a/spada/runtime/appliance_launcher.py
+++ b/spada/runtime/appliance_launcher.py
@@ -226,7 +226,7 @@ class ApplianceProgram:
             for name in wanted:
                 out_path = self.output_dir / os.path.basename(name)
                 try:
-                    launcher.download_artifact(name, str(out_path))
+                    launcher.download_artifact(name, str(out_path.absolute()))
                 except Exception as e:  # Missing artifacts should not lose the ones that do exist
                     print(f"\033[93mWarning:\033[0m could not download '{name}': {e}")
                     continue

--- a/spada/syntax/csl/benchmarking.py
+++ b/spada/syntax/csl/benchmarking.py
@@ -48,7 +48,7 @@ const timestamp = @import_module("<time>");
 def generate_sync_rectangle_code() -> RectangleBenchmarkingCode:
     return RectangleBenchmarkingCode(
         header="""
-param sync_params: comptime_struct;
+param sync_params;
 
 // Benchmarking counters
 const timestamp = @import_module("<time>");


### PR DESCRIPTION
On [Wafer-Scale Clusters](https://sdk.cerebras.ai/appliance-mode), compilation and runtime needs to run through appliance mode, which requires a different entry point to the compiler and runtime.

This new PR compiles with the SDK compiler, stages the appropriate files with SdkLauncher, and uses that launcher to run the script on the cluster directly.

Closes #62 as complete.