### PR TITLE
Fix non-memcpy benchmark path saving raw timestamps instead of cycle counts

### DIFF
--- a/spada/runtime/runtime.py
+++ b/spada/runtime/runtime.py
@@ -389,7 +389,7 @@ class Program:
             print("Copy-back complete.", flush=True)
 
             if self.benchmark and not self.metadata.memcpy_mode:
-                cycle_counts = copy_back_benchmark_data(self.runtime, self.metadata)
+                cycle_counts = copy_back_benchmark_cycles(self.runtime, self.metadata)
                 np.save(self.output_dir / "perf_cycles.npy", cycle_counts)
                 print_cycle_counts("Cycle count", cycle_counts)
 


### PR DESCRIPTION
In the non-memcpy benchmark path, `Program.run` calls `copy_back_benchmark_data`, which returns a `(cycle_start, cycle_stop)` tuple of absolute timestamps, and binds the tuple to `cycle_counts`. Consequently:

- `perf_cycles.npy` stores the two stacked timestamp arrays instead of elapsed cycle counts, and
- the printed "Cycle count" summary is computed from absolute timestamps.

The memcpy path already computes the difference correctly. This changes the call to `copy_back_benchmark_cycles`, which returns `cycle_stop - cycle_start`, making both paths consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
